### PR TITLE
Add infra email sending logic

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -71,6 +71,7 @@ class Properties {
     static def DEPLOYMENT_REPOSITORY_BRANCH
 
     static def EMAIL_TO_LIST
+    static def EMAIL_TO_LIST_INFRA
 
     /**
      * Initializing the properties

--- a/src/org/wso2/tg/jenkins/alert/Email.groovy
+++ b/src/org/wso2/tg/jenkins/alert/Email.groovy
@@ -26,12 +26,13 @@ import org.wso2.tg.jenkins.Properties
  *
  * @param subject subject of the Email
  * @param content body of the Email
+ * @param comma separated list of Email addresses
  */
-def send(subject,  content) {
+def send(subject,  content , recipients) {
     def log = new Logger()
     def props = Properties.instance
-    log.info("Sending mail to " + props.EMAIL_TO_LIST + " with the subject " + subject)
-    emailext(to: "${props.EMAIL_TO_LIST}",
+    log.info("Sending mail to " + recipients + " with the subject " + subject)
+    emailext(to: "${recipients}",
             subject: subject,
             body: content, mimeType: 'text/html')
 }

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -16,18 +16,15 @@
  * under the License.
  */
 
+
 import org.wso2.tg.jenkins.Logger
 import org.wso2.tg.jenkins.PipelineContext
-import org.wso2.tg.jenkins.alert.Slack
-import org.wso2.tg.jenkins.alert.Email
-import org.wso2.tg.jenkins.executors.TestGridExecutor
-import org.wso2.tg.jenkins.util.AWSUtils
-import org.wso2.tg.jenkins.executors.TestExecutor
 import org.wso2.tg.jenkins.Properties
-import org.wso2.tg.jenkins.util.Common
-import org.wso2.tg.jenkins.util.RuntimeUtils
-import org.wso2.tg.jenkins.util.WorkSpaceUtils
-import org.wso2.tg.jenkins.util.ConfigUtils
+import org.wso2.tg.jenkins.alert.Email
+import org.wso2.tg.jenkins.alert.Slack
+import org.wso2.tg.jenkins.executors.TestExecutor
+import org.wso2.tg.jenkins.executors.TestGridExecutor
+import org.wso2.tg.jenkins.util.*
 
 // The pipeline should reside in a call block
 def call() {
@@ -118,6 +115,7 @@ def call() {
                             }
                             // We need to set the repository properties
                             props.EMAIL_TO_LIST = tgYamlContent.emailToList
+                            props.EMAIL_TO_LIST_INFRA = tgYamlContent.infraFailureEmailToList
                             if(props.EMAIL_TO_LIST == null) {
                                 throw new Exception("emailToList property is not found in testgrid.yaml file")
                             }
@@ -197,12 +195,24 @@ def call() {
                             def environment = configUtil.getPropertyFromTestgridConfig("TESTGRID_ENVIRONMENT").toUpperCase()
                             email.send(
                                     "[${environment}][${currentBuild.result}] '${props.PRODUCT}' Test Results!" + " #(${env.BUILD_NUMBER})",
-                                    "${emailBody}")
+                                    "${emailBody}","${props.EMAIL_TO_LIST}" );
+
+                            //If there is an infra error email generated send it to infra email List recipients
+                            if (fileExists("${props.WORKSPACE}/InfraErrorEmail.html")) {
+                                echo "Infra Email to List : ${props.EMAIL_TO_LIST_INFRA}"
+                                def infraErrorEmailBody = readFile "${props.WORKSPACE}/InfraErrorEmail.html"
+                                email.send(
+                                        "[${environment}][${currentBuild.result}] '${props.PRODUCT}' Infra Failure!" + " #(${env.BUILD_NUMBER})",
+                                        "${infraErrorEmailBody}", "${props.EMAIL_TO_LIST_INFRA}");
+                            }else{
+                                log.warn("InfraErrorEmail not found !")
+                            }
+
                         } else {
                             log.warn("No SummarizedEmailReport.html file found!!")
                             email.send("'${props.PRODUCT}'#(${env.BUILD_NUMBER}) - SummarizedEmailReport.html " +
                                     "file not found", "Could not find the summarized email report ${env.BUILD_URL}. This is an error in " +
-                                    "testgrid.")
+                                    "testgrid.","${props.EMAIL_TO_LIST}")
                         }
                     } catch (e) {
                         currentBuild.result = "FAILURE"


### PR DESCRIPTION
## Purpose
Sending a separate email to the infra script maintainers after a build with the infra error summary

## Approach
If the infrastructure email is generated, send it to the infraEmailToList recipients.
