### PR TITLE
Avoid hanging pipline due to a dir not existing

### DIFF
--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -318,8 +318,12 @@ def handleException(Exception e, def testPlanId) {
 
     sh """
         set -o xtrace
-        echo "I'm writing to ${props.WORKSPACE}/${testPlanId}/builds/test-run.log"
-        echo '${errorMsg}' >> ${props.WORKSPACE}/${testPlanId}/builds/test-run.log
+        if [ -d ${props.WORKSPACE}/${testPlanId}/builds/test-run.log ]; then
+            echo "I'm writing to ${props.WORKSPACE}/${testPlanId}/builds/test-run.log"
+            echo '${errorMsg}' >> ${props.WORKSPACE}/${testPlanId}/builds/test-run.log
+        else
+            echo "Can not find ${props.WORKSPACE}/${testPlanId}/builds/test-run.log"
+        fi
     """
 
 }


### PR DESCRIPTION
## Purpose
Avoid hanging pipeline due to a dir not existing
There is a possibility to lost the directory for the parallel block if the parallel-executor got switched to another slave in the middle (due to a jenkins/tomcat restart, etc.)
This will ensure the pipeline would continue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes