### PR TITLE
Containerize run-testplan command execution

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -38,6 +38,7 @@ class Properties {
     final static def INFRA_LOCATION               = "InfraRepository"
     final static def DEPLOYMENT_LOCATION          = "DeploymentRepository"
     final static def SCENARIOS_LOCATION           = "ScenariosRepository"
+    final static def DOCKER_RUN_TP_JAVA_HOME      = "/opt/java/openjdk/"
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
@@ -49,12 +49,13 @@ def generateTesPlans(def product, def configYaml) {
  * @param url Jenkins build url for the test plan
  */
 def runTesPlans(def product, def testPlanFilePath, def workspace, def url) {
-    def props = Properties.instance
-    def log = new Logger()
-    log.info("Running Test-Plan: " + testPlanFilePath + " of product " + product + " in the workspace " + workspace)
-    sh """
+        def props = Properties.instance
+        def log = new Logger()
+        log.info("Running Test-Plan: " + testPlanFilePath + " of product " + product + " in the workspace " + workspace)
+        sh """
         cd ${props.TESTGRID_DIST_LOCATION}/${props.TESTGRID_NAME}
         export TESTGRID_HOME="${props.TESTGRID_HOME}"
+        export JAVA_HOME="${props.DOCKER_RUN_TP_JAVA_HOME}"
         ./testgrid run-testplan --product ${product} \
             --file ${testPlanFilePath} --workspace ${workspace} --url ${url}       
     """

--- a/src/org/wso2/tg/jenkins/util/ConfigUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/ConfigUtils.groovy
@@ -222,7 +222,7 @@ def resolveCredentials(value){
  * @param propName
  * @return property value
  */
-private def getPropertyFromTestgridConfig(String propName) {
+public def getPropertyFromTestgridConfig(String propName) {
     def props = Properties.instance
     def properties = readProperties file: "${props.CONFIG_PROPERTY_FILE_PATH}"
     def prop = properties[propName]

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -84,6 +84,7 @@ def call() {
                                     withCredentials([string(credentialsId: "GIT_WUM_USERNAME", variable: 'user'),
                                                      string(credentialsId: "GIT_WUM_PASSWORD", variable: 'pass')]) {
                                         sh """
+                                        mkdir -p ${props.WORKSPACE}
                                         curl --user $user:$pass -k -o ${props.WORKSPACE}/${
                                             props.TESTGRID_YAML_LOCATION
                                         } ${props.TESTGRID_YAML_URL}
@@ -91,8 +92,9 @@ def call() {
                                     }
                                 } else {
                                     sh """
-                                git clone ${props.TESTGRID_JOB_CONFIG_REPOSITORY}
-                                """
+                                        git clone ${props.TESTGRID_JOB_CONFIG_REPOSITORY}
+                                        mkdir -p ${props.WORKSPACE}
+                                    """
                                     def jobConfigExists = fileExists "testgrid-job-configs/${props.PRODUCT}-testgrid.yaml"
                                     log.info("The file location is set as " +
                                             "testgrid-job-configs/${props.PRODUCT}-testgrid.yaml and the exist flag is set to "
@@ -101,10 +103,9 @@ def call() {
                                         log.info("The testgrid yaml is found in remote repository " +
                                                 "testgrid-job-configs/${props.PRODUCT}-testgrid.yaml")
                                         sh """
-                                    cp "testgrid-job-configs/${props.PRODUCT}-testgrid.yaml" ${props.WORKSPACE}/${
-                                            props.TESTGRID_YAML_LOCATION
-                                        }
-                                """
+                                        cp "testgrid-job-configs/${props.PRODUCT}-testgrid.yaml" ${props.WORKSPACE}/${
+                                                props.TESTGRID_YAML_LOCATION}
+                                        """
                                     } else {
                                         log.info("The testgrid yaml is copied from the configFile provider.")
                                         configFileProvider(


### PR DESCRIPTION
## Purpose
Containerize `run-testplan` command execution

## Approach
Run a docker container and execute the run-testplan inside that.
The Dockerfile is available in https://github.com/wso2/testgrid/pull/1189
Docker Image is stored in an ECR in TestGrid AWS account.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/wso2/testgrid/pull/1189

## Note
URI for docker image is added to config.propeties file in each environment as `TG_DOCKER_URI`