### PR TITLE
Testgrid Kubernetes support: Pipeline changes

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -38,7 +38,7 @@ class Properties {
     final static def INFRA_LOCATION               = "InfraRepository"
     final static def DEPLOYMENT_LOCATION          = "DeploymentRepository"
     final static def SCENARIOS_LOCATION           = "ScenariosRepository"
-    final static def GKE_ACC_FILE_PATH            = "/data-bucket/key.json"
+    final static def GKE_ACC_FILE_PATH            = "data-bucket/key.json"
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -39,6 +39,9 @@ class Properties {
     final static def DEPLOYMENT_LOCATION          = "DeploymentRepository"
     final static def SCENARIOS_LOCATION           = "ScenariosRepository"
     final static def GKE_ACC_FILE_PATH            = "data-bucket/key.json"
+    final static def PUBLIC_ACCESS_KEY_LOCATION   = "data-bucket/testgrid-certs-v2.crt"
+    final static def PRIVATE_ACCESS_KEY_LOCATION  = "data-bucket/testgrid-certs-v2.csr"
+    final static def PRIVATE_ACCESS_CERTIFICATION = "data-bucket/testgrid-certs-v2.key"
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -38,6 +38,7 @@ class Properties {
     final static def INFRA_LOCATION               = "InfraRepository"
     final static def DEPLOYMENT_LOCATION          = "DeploymentRepository"
     final static def SCENARIOS_LOCATION           = "ScenariosRepository"
+    final static def GKE_ACC_FILE_PATH            = "workspace/data-bucket/key.json"
 
     // Job Properties which are set when init is called
     static def PRODUCT
@@ -74,6 +75,8 @@ class Properties {
     static def EMAIL_TO_LIST_INFRA
     static def EMAIL_REPLY_TO
 
+    static def PROVISION
+
     /**
      * Initializing the properties
      */
@@ -106,6 +109,7 @@ class Properties {
         EMAIL_TO_LIST_INFRA = getJobProperty("EMAIL_TO_LIST_INFRA", false)
         EMAIL_REPLY_TO = getJobProperty("EMAIL_REPLY_TO", false);
         TESTGRID_YAML_URL = getJobProperty("TESTGRID_YAML_URL", false)
+        PROVISION= getJobProperty("PROVISION",false)
     }
 
     /**

--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -39,9 +39,8 @@ class Properties {
     final static def DEPLOYMENT_LOCATION          = "DeploymentRepository"
     final static def SCENARIOS_LOCATION           = "ScenariosRepository"
     final static def GKE_ACC_FILE_PATH            = "data-bucket/key.json"
-    final static def PUBLIC_ACCESS_KEY_LOCATION   = "data-bucket/testgrid-certs-v2.crt"
-    final static def PRIVATE_ACCESS_KEY_LOCATION  = "data-bucket/testgrid-certs-v2.csr"
-    final static def PRIVATE_ACCESS_CERTIFICATION = "data-bucket/testgrid-certs-v2.key"
+    final static def GKE_K8S_SECRET_TLS_CERT   = "data-bucket/testgrid-certs-v2.crt"
+    final static def GKE_K8S_SECRET_TLS_KEY = "data-bucket/testgrid-certs-v2.key"
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -75,7 +75,7 @@ class Properties {
     static def EMAIL_TO_LIST_INFRA
     static def EMAIL_REPLY_TO
 
-    static def PROVISION
+    static def IAC_PROVIDER
 
     /**
      * Initializing the properties
@@ -109,7 +109,7 @@ class Properties {
         EMAIL_TO_LIST_INFRA = getJobProperty("EMAIL_TO_LIST_INFRA", false)
         EMAIL_REPLY_TO = getJobProperty("EMAIL_REPLY_TO", false);
         TESTGRID_YAML_URL = getJobProperty("TESTGRID_YAML_URL", false)
-        PROVISION= getJobProperty("PROVISION",false)
+        IAC_PROVIDER= getJobProperty("IAC_PROVIDER",false)
     }
 
     /**

--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -38,7 +38,7 @@ class Properties {
     final static def INFRA_LOCATION               = "InfraRepository"
     final static def DEPLOYMENT_LOCATION          = "DeploymentRepository"
     final static def SCENARIOS_LOCATION           = "ScenariosRepository"
-    final static def GKE_ACC_FILE_PATH            = "workspace/data-bucket/key.json"
+    final static def GKE_ACC_FILE_PATH            = "/data-bucket/key.json"
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -138,6 +138,7 @@ def prepareWorkspace(testPlanId, scenarioConfigs) {
             mkdir -p ${props.WORKSPACE}/${testPlanId}
             mkdir -p ${props.WORKSPACE}/${testPlanId}/builds
             mkdir -p ${props.WORKSPACE}/${testPlanId}/workspace
+            mkdir -p ${props.WORKSPACE}/${testPlanId}/workspace/data-bucket
             #Cloning should be done before unstashing TestGridYaml since its going to be injected
             #inside the cloned repository
             cd ${props.WORKSPACE}/${testPlanId}/workspace
@@ -168,6 +169,16 @@ def prepareWorkspace(testPlanId, scenarioConfigs) {
             chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.SSH_KEY_FILE_PATH}
             chmod 400 ${props.TESTGRID_HOME}/${props.SSH_KEY_FILE_PATH_INTG}
         """
+        }
+        if(props.PROVISION == "KUBERNETES"){
+            log.info("Using the service account accessKey.json file for authentication login")
+            withCredentials([file(credentialsId: 'GKE_BOT_GCE_SERVICE_ACC', variable: 'keyLocation')]) {
+                sh """
+            cp ${keyLocation} ${props.WORKSPACE}/${testPlanId}/${props.GKE_ACC_FILE_PATH}
+            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.GKE_ACC_FILE_PATH}
+        """
+            }
+
         }
         if (props.TEST_MODE == "WUM") {
             for (repo in scenarioConfigs) {

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -178,6 +178,25 @@ def prepareWorkspace(testPlanId, scenarioConfigs) {
             chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.GKE_ACC_FILE_PATH}
         """
             }
+            log.info("Public key is used to access the external endpoints of the deployment in the cluster")
+            withCredentials([file(credentialsId: 'PUBLIC_ACCESS_KEY', variable: 'publicAccessKeyLocation')]) {
+                sh """
+            cp ${publicAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.PUBLIC_ACCESS_KEY_LOCATION}
+            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PUBLIC_ACCESS_KEY_LOCATION}
+        """
+            }
+            withCredentials([file(credentialsId: 'PRIVATE_ACCESS_KEY', variable: 'privateAccessKeyLocation')]) {
+                sh """
+            cp ${privateAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_KEY_LOCATION}
+            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_CERTIFICATION}
+        """
+            }
+            withCredentials([file(credentialsId: 'PRIVATE_ACCESS_CERTIFICATION', variable: 'privateAccessCertification')]) {
+                sh """
+            cp ${privateAccessCertification} ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_CERTIFICATION}
+            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_CERTIFICATION}
+        """
+            }
 
         }
         if (props.TEST_MODE == "WUM") {

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -138,7 +138,7 @@ def prepareWorkspace(testPlanId, scenarioConfigs) {
             mkdir -p ${props.WORKSPACE}/${testPlanId}
             mkdir -p ${props.WORKSPACE}/${testPlanId}/builds
             mkdir -p ${props.WORKSPACE}/${testPlanId}/workspace
-            mkdir -p ${props.WORKSPACE}/${testPlanId}/workspace/data-bucket
+            mkdir -p ${props.WORKSPACE}/${testPlanId}/data-bucket
             #Cloning should be done before unstashing TestGridYaml since its going to be injected
             #inside the cloned repository
             cd ${props.WORKSPACE}/${testPlanId}/workspace

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -170,7 +170,7 @@ def prepareWorkspace(testPlanId, scenarioConfigs) {
             chmod 400 ${props.TESTGRID_HOME}/${props.SSH_KEY_FILE_PATH_INTG}
         """
         }
-        if(props.PROVISION == "KUBERNETES"){
+        if(props.IAC_PROVIDER == "KUBERNETES"){
             log.info("Using the service account accessKey.json file for authentication login")
             withCredentials([file(credentialsId: 'GKE_BOT_GCE_SERVICE_ACC', variable: 'keyLocation')]) {
                 sh """

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -181,17 +181,17 @@ def prepareWorkspace(testPlanId, scenarioConfigs) {
             log.info("Public key is used to access the external endpoints of the deployment in the cluster")
             withCredentials([file(credentialsId: 'GKE_K8S_SECRET_TLS_CERT', variable: 'publicAccessKeyLocation')]) {
                 sh """
-            cp ${publicAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.PUBLIC_ACCESS_KEY_LOCATION}
-            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PUBLIC_ACCESS_KEY_LOCATION}
+            cp ${publicAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.GKE_K8S_SECRET_TLS_CERT}
+            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.GKE_K8S_SECRET_TLS_CERT}
         """
             }
             withCredentials([file(credentialsId: 'GKE_K8S_SECRET_TLS_KEY', variable: 'privateAccessKeyLocation')]) {
                 sh """
-            cp ${privateAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_KEY_LOCATION}
-            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_CERTIFICATION}
+            cp ${privateAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.GKE_K8S_SECRET_TLS_KEY}
+            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.GKE_K8S_SECRET_TLS_KEY}
         """
             }
-           
+
         }
         if (props.TEST_MODE == "WUM") {
             for (repo in scenarioConfigs) {

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -179,25 +179,19 @@ def prepareWorkspace(testPlanId, scenarioConfigs) {
         """
             }
             log.info("Public key is used to access the external endpoints of the deployment in the cluster")
-            withCredentials([file(credentialsId: 'PUBLIC_ACCESS_KEY', variable: 'publicAccessKeyLocation')]) {
+            withCredentials([file(credentialsId: 'GKE_K8S_SECRET_TLS_CERT', variable: 'publicAccessKeyLocation')]) {
                 sh """
             cp ${publicAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.PUBLIC_ACCESS_KEY_LOCATION}
             chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PUBLIC_ACCESS_KEY_LOCATION}
         """
             }
-            withCredentials([file(credentialsId: 'PRIVATE_ACCESS_KEY', variable: 'privateAccessKeyLocation')]) {
+            withCredentials([file(credentialsId: 'GKE_K8S_SECRET_TLS_KEY', variable: 'privateAccessKeyLocation')]) {
                 sh """
             cp ${privateAccessKeyLocation} ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_KEY_LOCATION}
             chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_CERTIFICATION}
         """
             }
-            withCredentials([file(credentialsId: 'PRIVATE_ACCESS_CERTIFICATION', variable: 'privateAccessCertification')]) {
-                sh """
-            cp ${privateAccessCertification} ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_CERTIFICATION}
-            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.PRIVATE_ACCESS_CERTIFICATION}
-        """
-            }
-
+           
         }
         if (props.TEST_MODE == "WUM") {
             for (repo in scenarioConfigs) {

--- a/src/org/wso2/tg/jenkins/util/ConfigUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/ConfigUtils.groovy
@@ -1,4 +1,4 @@
-ayy/*
+/*
  * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,

--- a/src/org/wso2/tg/jenkins/util/ConfigUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/ConfigUtils.groovy
@@ -1,4 +1,4 @@
-/*
+ayy/*
  * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -122,6 +122,7 @@ def call() {
                                 props.EMAIL_TO_LIST = tgYamlContent.emailToList
                                 props.EMAIL_TO_LIST_INFRA = tgYamlContent.infraFailureEmailToList
                                 props.IAC_PROVIDER = tgYamlContent.infrastructureConfig.iacProvider
+                                log.info("iacProvider " + props.IAC_PROVIDER)
                                 if (props.EMAIL_TO_LIST == null) {
                                     throw new Exception("emailToList property is not found in testgrid.yaml file")
                                 }

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -121,6 +121,7 @@ def call() {
                                 // We need to set the repository properties
                                 props.EMAIL_TO_LIST = tgYamlContent.emailToList
                                 props.EMAIL_TO_LIST_INFRA = tgYamlContent.infraFailureEmailToList
+                                props.PROVISION = tgYamlContent.provision
                                 if (props.EMAIL_TO_LIST == null) {
                                     throw new Exception("emailToList property is not found in testgrid.yaml file")
                                 }

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -121,7 +121,7 @@ def call() {
                                 // We need to set the repository properties
                                 props.EMAIL_TO_LIST = tgYamlContent.emailToList
                                 props.EMAIL_TO_LIST_INFRA = tgYamlContent.infraFailureEmailToList
-                                props.PROVISION = tgYamlContent.provision
+                                props.IAC_PROVIDER = tgYamlContent.infrastructureConfig.iacProvider
                                 if (props.EMAIL_TO_LIST == null) {
                                     throw new Exception("emailToList property is not found in testgrid.yaml file")
                                 }


### PR DESCRIPTION
## Purpose
store service account access key in jenkins credential management and use it in the jenkins pipeline
## Approach
The credential file is called in the jenkins pipeline and the credential file is used in the authentication process. After the validation, the file is deleted.
