### PR TITLE
Add error handling if no new updated product is found in UAT.

### DIFF
--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -83,8 +83,8 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
                       """
 
-                      def live_ts = sh(script: 'get-wum-uat-products.sh --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
-                      def uat_ts = sh(script: 'get-wum-uat-products.sh --get-uat-timestamp', returnStdout: true).split("\r?\n")[2]
+                      def live_ts = sh(script: '${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products.sh --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
+                      def uat_ts = sh(script: '${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products.sh --get-uat-timestamp', returnStdout: true).split("\r?\n")[2]
 
                       echo "uat timestamp: ${uat_ts} | live timestamp: ${live_ts}"
 

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -83,8 +83,8 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
                       """
 
-                      def live_ts = sh(script: 'get-wum-uat-products --get-live-timestamp'), returnStdout: true).split("\r?\n")[2]
-                      def uat_ts = sh(script: 'get-wum-uat-products --get-uat-timestamp'), returnStdout: true).split("\r?\n")[2]
+                      def live_ts = sh(script: 'get-wum-uat-products --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
+                      def uat_ts = sh(script: 'get-wum-uat-products --get-uat-timestamp', returnStdout: true).split("\r?\n")[2]
 
                       echo "uat timestamp: ${uat_ts} | live timestamp: ${live_ts}"
 

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -81,8 +81,18 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS
                         git clone ${SCENARIOS_REPOSITORY}
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
-                        sh get-wum-uat-products.sh
+
+                        sh get-wum-uat-products.sh --check-update-status
                       """
+
+                      if ( $uat_status == 0 ){
+                        currentBuild.result='SUCCESS'
+                        return
+                      }
+                    sh """
+                      sh get-wum-uat-products.sh --get-job-list
+                    """
+
                     }
                 }
             }

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -80,13 +80,20 @@ def call() {
                         mkdir WUM_LOGS
                         cd ${WORKSPACE}/WUM_LOGS
                         git clone ${SCENARIOS_REPOSITORY}
-        
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
                         sh get-wum-uat-products.sh
                       """
                     }
                 }
             }
+        }
+
+        stage('build-image') {
+          steps {
+            echo "Building prodcut images with latest updates from UAT ... "
+            build job: 'nishika-wum-k8s-job-runner'
+            echo "Product image build is successful."
+          }
         }
 
         stage('parallel-run') {

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -90,6 +90,7 @@ def call() {
                       echo "uat timestamp: ${uat_ts} | live timestamp: ${live_ts}"
 
                       if ( "${uat_ts}" == "${live_ts}" ){
+                        echo "There are no updated product packs for the given timestamp in UAT. Hence Skipping the process."
                         currentBuild.result='SUCCESS'
                         return
                       }

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -83,8 +83,8 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
                       """
 
-                      def live_ts = sh(script: '${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
-                      def uat_ts = sh(script: '${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products --get-uat-timestamp', returnStdout: true).split("\r?\n")[2]
+                      def live_ts = sh(script: 'get-wum-uat-products.sh --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
+                      def uat_ts = sh(script: 'get-wum-uat-products.sh --get-uat-timestamp', returnStdout: true).split("\r?\n")[2]
 
                       echo "uat timestamp: ${uat_ts} | live timestamp: ${live_ts}"
 

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -81,16 +81,19 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS
                         git clone ${SCENARIOS_REPOSITORY}
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
-
-                        sh get-wum-uat-products.sh --check-update-status
                       """
 
-                      if ( $uat_status == 0 ){
+                      def live_ts = sh(script: 'get-wum-uat-products --get-live-timestamp)', returnStdout: true).split("\r?\n")[2]
+                      def uat_ts = sh(script: 'get-wum-uat-products --get-uat-timestamp)', returnStdout: true).split("\r?\n")[2]
+
+                      echo "uat timestamp: ${uat_ts} | live timestamp: ${live_ts}"
+
+                      if ( "${uat_ts}" == "${live_ts}" ){
                         currentBuild.result='SUCCESS'
                         return
                       }
                     sh """
-                      sh get-wum-uat-products.sh --get-job-list
+                      sh get-wum-uat-products.sh --get-job-list ${live_ts}
                     """
 
                     }

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -81,6 +81,7 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS
                         git clone ${SCENARIOS_REPOSITORY}
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
+                        chmod +x get-wum-uat-products.sh
                       """
 
                       def live_ts = sh(script: '${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products.sh --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
@@ -93,7 +94,7 @@ def call() {
                         return
                       }
                     sh """
-                      sh get-wum-uat-products.sh --get-job-list ${live_ts}
+                      sh ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products.sh --get-job-list ${live_ts}
                     """
 
                     }

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -83,8 +83,8 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
                       """
 
-                      def live_ts = sh(script: 'get-wum-uat-products --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
-                      def uat_ts = sh(script: 'get-wum-uat-products --get-uat-timestamp', returnStdout: true).split("\r?\n")[2]
+                      def live_ts = sh(script: '${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products --get-live-timestamp', returnStdout: true).split("\r?\n")[2]
+                      def uat_ts = sh(script: '${WORKSPACE}/WUM_LOGS/test-integration-tests-runner/get-wum-uat-products --get-uat-timestamp', returnStdout: true).split("\r?\n")[2]
 
                       echo "uat timestamp: ${uat_ts} | live timestamp: ${live_ts}"
 

--- a/vars/WUMUpdateVerifier.groovy
+++ b/vars/WUMUpdateVerifier.groovy
@@ -83,8 +83,8 @@ def call() {
                         cd ${WORKSPACE}/WUM_LOGS/test-integration-tests-runner
                       """
 
-                      def live_ts = sh(script: 'get-wum-uat-products --get-live-timestamp)', returnStdout: true).split("\r?\n")[2]
-                      def uat_ts = sh(script: 'get-wum-uat-products --get-uat-timestamp)', returnStdout: true).split("\r?\n")[2]
+                      def live_ts = sh(script: 'get-wum-uat-products --get-live-timestamp'), returnStdout: true).split("\r?\n")[2]
+                      def uat_ts = sh(script: 'get-wum-uat-products --get-uat-timestamp'), returnStdout: true).split("\r?\n")[2]
 
                       echo "uat timestamp: ${uat_ts} | live timestamp: ${live_ts}"
 


### PR DESCRIPTION
## Purpose
>  Exit 0 from the  [get-wum-uat-products.sh](https://github.com/wso2-incubator/test-integration-tests-runner/blob/master/get-wum-uat-products.sh) if no UAT update is found for a specific timestamp is not handled through Jenkins pipeline [WUMUpdateVerifier.groovy](https://github.com/NishikaDeSilva/testgrid-jenkins-library/blob/dev/vars/WUMUpdateVerifier.groovy)

## Goals
> Alter [WUMUpdateVerifier.groovy](https://github.com/NishikaDeSilva/testgrid-jenkins-library/blob/dev/vars/WUMUpdateVerifier.groovy) to handle said purpose.

## Approach
> Alter stage 'preparation' to check for new updates in UAT before proceeding further.