### PR TITLE
 Add run as schedule feature

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -41,6 +41,12 @@ class Properties {
     final static def GKE_ACC_FILE_PATH            = "data-bucket/key.json"
     final static def GKE_K8S_SECRET_TLS_CERT   = "data-bucket/testgrid-certs-v2.crt"
     final static def GKE_K8S_SECRET_TLS_KEY = "data-bucket/testgrid-certs-v2.key"
+    final static def MANUAL_SCHEDULE              = "manual"
+    final static def DAILY_SCHEDULE               = "daily"
+    final static def WEEKLY_SCHEDULE              = "weekly"
+    final static def MONTHLY_SCHEDULE             = "monthly"
+    final static def MONTHLY_SCHEDULED_DAY        = 1
+    final static def WEEKLY_SCHEDULED_DAY         = Calendar.MONDAY
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
@@ -18,6 +18,7 @@
 
 package org.wso2.tg.jenkins.executors
 
+import hudson.model.Cause
 import org.wso2.tg.jenkins.Logger
 import org.wso2.tg.jenkins.Properties
 
@@ -34,10 +35,47 @@ def generateTesPlans(def product, def configYaml) {
         export TESTGRID_HOME="${props.TESTGRID_HOME}"
         ./testgrid generate-test-plan \
             --product ${product} \
-            --file ${configYaml}
+            --file ${configYaml} 
         echo "Following Test plans were generated : "
         ls -al ${props.WORKSPACE}/test-plans
     """
+}
+
+/**
+ * Select the schedule considering build cause. If the build has been triggered by a user return
+ * the schedule as manual and otherwise return time based period schedule.
+ *
+ * @param build current build
+ * @return schedule the schedule use for generate infrastructure combinations
+ */
+static def selectSchedule(build) {
+    def props = Properties.instance
+    // Check if the build was triggered by some jenkins user
+    def userId = build.rawBuild.getCause(Cause.UserIdCause.class).properties.userId
+    if (userId != null) {
+        return props.MANUAL_SCHEDULE
+    }
+    return selectTimePeriod()
+}
+
+/**
+ * Select the schedule considering the present date.
+ *
+ * @return schedule the schedule use for generate infrastructure combinations
+ */
+static def selectTimePeriod(){
+    def props = Properties.instance
+    // Check day of the month and day of the week
+    Calendar date = Calendar.getInstance()
+    int dayOfMonth = date.get(Calendar.DAY_OF_MONTH)
+    int dayOfTheWeek = date.get(Calendar.DAY_OF_WEEK)
+    if (dayOfMonth == props.MONTHLY_SCHEDULED_DAY) {
+        return props.MONTHLY_SCHEDULE
+    } else if (dayOfTheWeek == props.WEEKLY_SCHEDULED_DAY) {
+        return props.WEEKLY_SCHEDULE
+    } else {
+        return props.DAILY_SCHEDULE
+    }
 }
 
 /**

--- a/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
@@ -35,7 +35,7 @@ def generateTesPlans(def product, def configYaml) {
         export TESTGRID_HOME="${props.TESTGRID_HOME}"
         ./testgrid generate-test-plan \
             --product ${product} \
-            --file ${configYaml} 
+            --file ${configYaml}
         echo "Following Test plans were generated : "
         ls -al ${props.WORKSPACE}/test-plans
     """

--- a/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
@@ -25,7 +25,7 @@ import org.wso2.tg.jenkins.Properties
  *
  * @param filePath full qualified path of jobconfig.yaml
  */
-def createJobConfigYamlFile(def filePath) {
+def createJobConfigYamlFile(def filePath, def schedule) {
 
     def props = Properties.instance
     def log = new Logger()
@@ -38,6 +38,7 @@ def createJobConfigYamlFile(def filePath) {
     echo 'deploymentRepository: "workspace/${props.DEPLOYMENT_LOCATION}/"' >> ${filePath}
     echo 'scenarioTestsRepository: "workspace/${props.SCENARIOS_LOCATION}"' >> ${filePath}
     echo 'testgridYamlLocation: "${props.TESTGRID_YAML_LOCATION}"' >> ${filePath}
+    echo 'schedule: "${schedule}"' >> ${filePath} 
     echo 'properties:' >> ${filePath}
     echo '  PRODUCT_GIT_URL: "${props.PRODUCT_GIT_URL}"' >> ${filePath}
     echo '  PRODUCT_GIT_BRANCH: "${props.PRODUCT_GIT_BRANCH}"' >> ${filePath}

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -17,6 +17,7 @@
  */
 
 
+import hudson.model.Cause
 import org.wso2.tg.jenkins.Logger
 import org.wso2.tg.jenkins.PipelineContext
 import org.wso2.tg.jenkins.Properties
@@ -127,8 +128,10 @@ def call() {
                                     throw new Exception("emailToList property is not found in testgrid.yaml file")
                                 }
                                 log.info("Creating Job config in " + props.JOB_CONFIG_YAML_PATH)
+                                // Select schedule by using current build information
+                                def schedule = tgExecutor.selectSchedule(currentBuild)
                                 // Creating the job config file
-                                ws.createJobConfigYamlFile("${props.JOB_CONFIG_YAML_PATH}")
+                                ws.createJobConfigYamlFile("${props.JOB_CONFIG_YAML_PATH}", schedule)
                                 sh """
                                 echo The job-config.yaml content :
                                 cat ${props.JOB_CONFIG_YAML_PATH}


### PR DESCRIPTION
## Purpose
> Improve the efficiency of Test Grid test running schedule and reduce the cost for Test Grid process.

## Goals
> Reduce cost 
> Add more flexibility to the Test Grid schedule
> Automate the test running process

## Approach
> Introduce scheduling method for test running as manual, daily, weekly and monthly. The test will be triggered automatically by time and using the date and day the pipeline will decide the running schedule and add the parameters according to that to jobcofig configuration file.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> WSO2 TestGrid 1.0
 
## Learning
> N/A