### PR TITLE
Parameterize the Jenkins agent label

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -56,6 +56,7 @@ class Properties {
     final static def MONTHLY_SCHEDULE             = "monthly"
     final static def MONTHLY_SCHEDULED_DAY        = 1
     final static def WEEKLY_SCHEDULED_DAY         = Calendar.MONDAY
+    final static def AGENT_NODE_LABEL_IDENTIFIER  = "agentNodeLabel"
 
     // Job Properties which are set when init is called
     static def PRODUCT
@@ -93,6 +94,7 @@ class Properties {
     static def EMAIL_REPLY_TO
 
     static def IAC_PROVIDER
+    static def AGENT_NODE_LABEL
 
     /**
      * Initializing the properties
@@ -127,6 +129,8 @@ class Properties {
         EMAIL_REPLY_TO = getJobProperty("EMAIL_REPLY_TO", false);
         TESTGRID_YAML_URL = getJobProperty("TESTGRID_YAML_URL", false)
         IAC_PROVIDER= getJobProperty("IAC_PROVIDER",false)
+        AGENT_NODE_LABEL = getAgentNodeLabel()
+
     }
 
     /**
@@ -184,5 +188,13 @@ class Properties {
             throw new Exception("A mandatory property " + key + " is empty or null")
         }
         return cred
+    }
+
+    private def getAgentNodeLabel() {
+        prop = getJobProperty(AGENT_NODE_LABEL_IDENTIFIER, false)
+        if (prop == null || prop.trim() == "") {
+            prop = "default"
+        }
+        return prop
     }
 }

--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -191,10 +191,10 @@ class Properties {
     }
 
     private def getAgentNodeLabel() {
-        prop = getJobProperty(AGENT_NODE_LABEL_IDENTIFIER, false)
-        if (prop == null || prop.trim() == "") {
-            prop = "default"
+        def label = getJobProperty(AGENT_NODE_LABEL_IDENTIFIER, false)
+        if (label == null || label.trim() == "") {
+            label = "default"
         }
-        return prop
+        return label
     }
 }

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -48,7 +48,7 @@ def call() {
     pipeline {
         agent {
             node {
-                label ""
+                label "${props.AGENT_NODE_LABEL}"
                 customWorkspace "${props.WORKSPACE}"
             }
         }


### PR DESCRIPTION
## Purpose
> Right now, there is no option to parameterize the `label` of the Jenkins agent nodes. The `label` is used to specify which type of agent the job should run on. If someone wants to run some tests with a custom Jenkins agent, the only option is to fork this entire repo and change the `label` value under the `agent` section in Pipeline.groovy. With this fix, anyone can use a custom agent by simply specifying the parameter `agentNodeLabel` by selecting the `This project is parameterized` option in the configure section. 

## Goals
> Provide support for custom Jenkins agents OOTB.
