### PR TITLE
Remove tools config from pipeline def

### DIFF
--- a/vars/Escalate.groovy
+++ b/vars/Escalate.groovy
@@ -42,9 +42,6 @@ def call() {
                 customWorkspace "${props.WORKSPACE}"
             }
         }
-        tools {
-            jdk 'jdk8'
-        }
 
         stages {
             stage('Generate Escalations') {


### PR DESCRIPTION
## Purpose
> Remove the `jdk` config from the pipeline configuration. This way the `JAVA_HOME` will be picked from the environment variable preconfigured in the Jenkins master/slave node. 

