### PR TITLE
Provide the ability to override the infrastructure list via Jenkins

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -57,6 +57,7 @@ class Properties {
     final static def MONTHLY_SCHEDULED_DAY        = 1
     final static def WEEKLY_SCHEDULED_DAY         = Calendar.MONDAY
     final static def AGENT_NODE_LABEL_IDENTIFIER  = "agentNodeLabel"
+    final static def INFRA_OVERRIDES_PARAM        = "infraOverrides"
 
     // Job Properties which are set when init is called
     static def PRODUCT
@@ -95,6 +96,7 @@ class Properties {
 
     static def IAC_PROVIDER
     static def AGENT_NODE_LABEL
+    static def INFRA_OVERRIDES
 
     /**
      * Initializing the properties
@@ -130,6 +132,7 @@ class Properties {
         TESTGRID_YAML_URL = getJobProperty("TESTGRID_YAML_URL", false)
         IAC_PROVIDER= getJobProperty("IAC_PROVIDER",false)
         AGENT_NODE_LABEL = getAgentNodeLabel()
+        INFRA_OVERRIDES = getInfraOverrides()
 
     }
 
@@ -196,5 +199,15 @@ class Properties {
             label = "default"
         }
         return label
+    }
+
+    private def getInfraOverrides () {
+        def infra_params = getJobProperty(INFRA_OVERRIDES_PARAM, false)
+        if (infra_params != null && infra_params.trim() != "") {
+            def param_list = infra_params.split(",")
+            return param_list
+        } else {
+            return null
+        }
     }
 }

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -152,7 +152,10 @@ def call() {
 
                                 //check if infra includes have been overridden
                                 if(props.INFRA_OVERRIDES != null) {
-                                    tgYamlContent.infrastructureConfig.includes = props.INFRA_OVERRIDES
+                                    tgYamlContent.infrastructureConfig.includes = []
+                                    for (String item : props.INFRA_OVERRIDES) {
+                                        tgYamlContent.infrastructureConfig.includes.add(item)
+                                    }
                                 }
 
                                 //remove the existing testgrid yaml file before creating the new one

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -154,7 +154,7 @@ def call() {
                                 if(props.INFRA_OVERRIDES != null) {
                                     tgYamlContent.infrastructureConfig.includes = []
                                     for (String item : props.INFRA_OVERRIDES) {
-                                        tgYamlContent.infrastructureConfig.includes.add(item)
+                                        tgYamlContent.infrastructureConfig.includes.add(item.trim())
                                     }
                                 }
 

--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -150,6 +150,11 @@ def call() {
                                 def commonConfigs = readProperties file: "${props.WORKSPACE}/common-configs.properties"
                                 tgYamlContent = config.addCommonConfigsToTestGridYaml(tgYamlContent, commonConfigs)
 
+                                //check if infra includes have been overridden
+                                if(props.INFRA_OVERRIDES != null) {
+                                    tgYamlContent.infrastructureConfig.includes = props.INFRA_OVERRIDES
+                                }
+
                                 //remove the existing testgrid yaml file before creating the new one
                                 sh " rm ${props.WORKSPACE}/${props.TESTGRID_YAML_LOCATION}"
                                 //write the new testgrid yaml file after adding new config values


### PR DESCRIPTION
## Purpose
> According to the current implementation, once the infrastructure list has been configured in the config YAML file, there is no way to override it. Due to this, even if one infrastructure combination fails, all the other combinations also have to be tested since there is no way to temporarily override the infra list. This results in a waste or time and increased cost.

> With this fix, a new parameter named `infraOverrides` is introduced which can be specified via Jenkins prior to manually triggering the build. When this property is specified, it will override the list of infrastructures specified in the config YAML and only the list specified via this property will be considered when creating the test plans. The required infrastructure list should be entered as a comma-separated list as follows;

```
infraOverrides=CentOS-7.5,MySQL-5.7,OPEN_JDK8
```

