### PR TITLE
Add apim-pre-release build param

### DIFF
--- a/integration.groovy
+++ b/integration.groovy
@@ -30,6 +30,9 @@ stages {
             script {
                 cfn_repo_url="https://github.com/wso2/testgrid.git"
                 cfn_repo_branch="master"
+                if (apim_pre_release.toBoolean()){
+                    cfn_repo_branch="apim-pre-release"
+                }
                 if (use_wum.toBoolean()){
                     updateType="wum"
                 }else{
@@ -224,6 +227,10 @@ def sendEmail(deploymentDirectories, updateType) {
         <tr>
             <td>Used Staging as Update</td>
             <td>${use_staging}</td>
+        </tr>
+        <tr>
+            <td>Used APIM pre-release</td>
+            <td>${apim_pre_release}</td>
         </tr>
         <tr>
             <td>Operating Systems</td>

--- a/main.groovy
+++ b/main.groovy
@@ -273,10 +273,6 @@ def sendEmail(deploymentDirectories, updateType) {
             <td>${use_staging}</td>
         </tr>
         <tr>
-            <td>Used APIM pre-release</td>
-            <td>${apim_pre_release}</td>
-        </tr>
-        <tr>
             <td>Operating Systems</td>
             <td>${os_list}</td>
         </tr>

--- a/main.groovy
+++ b/main.groovy
@@ -273,6 +273,10 @@ def sendEmail(deploymentDirectories, updateType) {
             <td>${use_staging}</td>
         </tr>
         <tr>
+            <td>Used APIM pre-release</td>
+            <td>${apim_pre_release}</td>
+        </tr>
+        <tr>
             <td>Operating Systems</td>
             <td>${os_list}</td>
         </tr>


### PR DESCRIPTION
## Purpose
Add new build param called apim_pre_release. Currently, the test grid only supports GA releases that are included in the AMI. The new param will help with future changes that we will add to support running integration tests on APIM pre-release versions.