### PR TITLE
Update supported APIM JDK list

### DIFF
--- a/scripts/apim/intg/infra.json
+++ b/scripts/apim/intg/infra.json
@@ -14,6 +14,10 @@
 			"file_name": "amazon-corretto-11.0.7.10.1-linux-x64"
 		},
 		{
+			"name": "CORRETTO_JDK17",
+			"file_name": "amazon-corretto-17.0.5.8.1-linux-x64"
+		},
+		{
 			"name": "OPEN_JDK8",
 			"file_name": "OpenJDK8U-jdk_x64_linux_8u275b01"
 		},

--- a/scripts/apim/intg/infra.json
+++ b/scripts/apim/intg/infra.json
@@ -6,14 +6,6 @@
 			"file_name": "OpenJDK8U-jdk_x64_linux_hotspot_8u252b09"
 		},
 		{
-			"name": "ORACLE_JDK8",
-			"file_name": "jdk-8u251-linux-x64"
-		},
-		{
-			"name": "ORACLE_JDK11",
-			"file_name": "jdk-11.0.7_linux-x64_bin"
-		},
-		{
 			"name": "CORRETTO_JDK8",
 			"file_name": "amazon-corretto-8.252.09.1-linux-x64"
 		},


### PR DESCRIPTION
## Purpose
1. Removing unused OracleJDK 18 & 11
2. Adding Amazon CorrettoJDK 17