### PR TITLE
Update OpenJDK 11 version to 11.0.25_9

### DIFF
--- a/scripts/apim/intg/infra.json
+++ b/scripts/apim/intg/infra.json
@@ -28,6 +28,10 @@
 		{
 			"name": "ADOPT_OPEN_JDK17",
 			"file_name": "OpenJDK17U-jdk_x64_linux_hotspot_17.0.5_8"
+		},
+		{
+			"name": "ADOPT_OPEN_JDK21",
+			"file_name": "OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13"
 		}
 	],
     "jdbc": 

--- a/scripts/apim/intg/infra.json
+++ b/scripts/apim/intg/infra.json
@@ -23,7 +23,7 @@
 		},
 		{
 			"name": "ADOPT_OPEN_JDK11",
-			"file_name": "OpenJDK11U-jdk_x64_linux_hotspot_11.0.7_10"
+			"file_name": "OpenJDK11U-jdk_x64_linux_hotspot_11.0.25_9"
 		},
 		{
 			"name": "ADOPT_OPEN_JDK17",


### PR DESCRIPTION
## Purpose
This PR updates the OpenJDK 11 version used in testgrid to 11.0.25_9.

Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/7896
