### PR TITLE
Apim profile automation parallel builds

### DIFF
--- a/kubernetes/product-deployment/320_main.jenkins
+++ b/kubernetes/product-deployment/320_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        SHORT_PRODUCT_VERSION = '320'
     }
     stages {
         stage('Clone repo') {

--- a/kubernetes/product-deployment/321_main.jenkins
+++ b/kubernetes/product-deployment/321_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        SHORT_PRODUCT_VERSION = '321'
     }
     stages {
         stage('Clone repo') {

--- a/kubernetes/product-deployment/400_main.jenkins
+++ b/kubernetes/product-deployment/400_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        SHORT_PRODUCT_VERSION = '400'
     }
     stages {
         stage('Clone repo') {

--- a/kubernetes/product-deployment/410_main.jenkins
+++ b/kubernetes/product-deployment/410_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        SHORT_PRODUCT_VERSION = '410'
     }
     stages {
         stage('Clone repo') {

--- a/kubernetes/product-deployment/420_main.jenkins
+++ b/kubernetes/product-deployment/420_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        SHORT_PRODUCT_VERSION = '420'
     }
     stages {
         stage('Clone repo') {

--- a/kubernetes/product-deployment/430_main.jenkins
+++ b/kubernetes/product-deployment/430_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        SHORT_PRODUCT_VERSION = '430'
     }
     stages {
         stage('Clone repo') {

--- a/kubernetes/product-deployment/440_main.jenkins
+++ b/kubernetes/product-deployment/440_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        SHORT_PRODUCT_VERSION = '440'
     }
     stages {
         stage('Clone repo') {

--- a/kubernetes/product-deployment/scripts/cleanup.sh
+++ b/kubernetes/product-deployment/scripts/cleanup.sh
@@ -20,8 +20,6 @@
 
 productName=$1;
 ./kubernetes/product-deployment/scripts/"$productName"/cleanup.sh
-echo "Scaling node group instances to zero."
-# eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=0
 echo "Deleting RDS database."
 aws cloudformation delete-stack --region ${EKS_CLUSTER_REGION} --stack-name ${RDS_STACK_NAME}
 aws cloudformation wait stack-delete-complete --region ${EKS_CLUSTER_REGION} --stack-name ${RDS_STACK_NAME}

--- a/kubernetes/product-deployment/scripts/cleanup.sh
+++ b/kubernetes/product-deployment/scripts/cleanup.sh
@@ -27,7 +27,7 @@ aws cloudformation delete-stack --region ${EKS_CLUSTER_REGION} --stack-name ${RD
 aws cloudformation wait stack-delete-complete --region ${EKS_CLUSTER_REGION} --stack-name ${RDS_STACK_NAME}
 
 echo "Listing RDS Snaphots with instance identifier: testgrid-rds ..."
-snapshot_identifiers=$(aws rds describe-db-snapshots --db-instance-identifier testgrid-rds-${product_version} | jq -r '.DBSnapshots[].DBSnapshotIdentifier')
+snapshot_identifiers=$(aws rds describe-db-snapshots --db-instance-identifier testgrid-rds-${SHORT_PRODUCT_VERSION} | jq -r '.DBSnapshots[].DBSnapshotIdentifier')
 
 # Convert the space-separated snapshot identifiers to an array
 IFS=$'\n' read -rd '' -a snapshot_array <<< "$snapshot_identifiers"

--- a/kubernetes/product-deployment/scripts/cleanup.sh
+++ b/kubernetes/product-deployment/scripts/cleanup.sh
@@ -21,7 +21,7 @@
 productName=$1;
 ./kubernetes/product-deployment/scripts/"$productName"/cleanup.sh
 echo "Scaling node group instances to zero."
-eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=0
+# eksctl scale nodegroup --region ${EKS_CLUSTER_REGION} --cluster ${EKS_CLUSTER_NAME} --name ng-1 --nodes=0
 echo "Deleting RDS database."
 aws cloudformation delete-stack --region ${EKS_CLUSTER_REGION} --stack-name ${RDS_STACK_NAME}
 aws cloudformation wait stack-delete-complete --region ${EKS_CLUSTER_REGION} --stack-name ${RDS_STACK_NAME}

--- a/kubernetes/product-deployment/scripts/cleanup.sh
+++ b/kubernetes/product-deployment/scripts/cleanup.sh
@@ -27,7 +27,7 @@ aws cloudformation delete-stack --region ${EKS_CLUSTER_REGION} --stack-name ${RD
 aws cloudformation wait stack-delete-complete --region ${EKS_CLUSTER_REGION} --stack-name ${RDS_STACK_NAME}
 
 echo "Listing RDS Snaphots with instance identifier: testgrid-rds ..."
-snapshot_identifiers=$(aws rds describe-db-snapshots --db-instance-identifier testgrid-rds | jq -r '.DBSnapshots[].DBSnapshotIdentifier')
+snapshot_identifiers=$(aws rds describe-db-snapshots --db-instance-identifier testgrid-rds-${product_version} | jq -r '.DBSnapshots[].DBSnapshotIdentifier')
 
 # Convert the space-separated snapshot identifiers to an array
 IFS=$'\n' read -rd '' -a snapshot_array <<< "$snapshot_identifiers"

--- a/kubernetes/product-deployment/scripts/create-database.sh
+++ b/kubernetes/product-deployment/scripts/create-database.sh
@@ -49,6 +49,7 @@ aws cloudformation create-stack \
     ParameterKey=pDbEngine,ParameterValue="$dbEngine" \
     ParameterKey=pDbVersion,ParameterValue="${db_version}" \
     ParameterKey=pDbInstanceClass,ParameterValue="${db_instance_class}"  \
+    ParameterKey=pProductVersion,ParameterValue="${product_version}" \
     ParameterKey=pProductTagName,ParameterValue="${product_name}-${product_version}-testgrid-kubernetes-deployment" || { echo 'Failed to create RDS stack.';  exit 1; }
 
 # Wait for RDS DB to come alive.

--- a/kubernetes/product-deployment/scripts/create-database.sh
+++ b/kubernetes/product-deployment/scripts/create-database.sh
@@ -49,7 +49,7 @@ aws cloudformation create-stack \
     ParameterKey=pDbEngine,ParameterValue="$dbEngine" \
     ParameterKey=pDbVersion,ParameterValue="${db_version}" \
     ParameterKey=pDbInstanceClass,ParameterValue="${db_instance_class}"  \
-    ParameterKey=pProductVersion,ParameterValue="${product_version}" \
+    ParameterKey=pProductVersion,ParameterValue="${SHORT_PRODUCT_VERSION}" \
     ParameterKey=pProductTagName,ParameterValue="${product_name}-${product_version}-testgrid-kubernetes-deployment" || { echo 'Failed to create RDS stack.';  exit 1; }
 
 # Wait for RDS DB to come alive.

--- a/kubernetes/product-deployment/scripts/testgrid-rds-cf.yaml
+++ b/kubernetes/product-deployment/scripts/testgrid-rds-cf.yaml
@@ -38,6 +38,8 @@ Parameters:
       - db.m3.2xlarge
       - db.m4.large
       - db.m4.xlarge
+  pProductVersion:
+    Type: String
   pProductTagName:
     Type: String
 
@@ -53,7 +55,7 @@ Resources:
       StorageType: gp2
       PubliclyAccessible: True
       AllocatedStorage: "20"
-      DBInstanceIdentifier: testgrid-rds
+      DBInstanceIdentifier: !Join ["-", ["testgrid-rds", !Ref pProductVersion]]
       LicenseModel:
         !If [UseLicensedVersion, license-included, !Ref "AWS::NoValue"]
       Tags:


### PR DESCRIPTION
## Purpose
Currently, when running profile tests for version 4.4.0 and below, it is not possible to run multiple builds in parallel because they use the same ingress names and Fargate profile. This PR addresses that issue.

## Goals
Separate CloudFormation resources for each version.

## Approach
- Introduced `SHORT_PRODUCT_VERSION`, as CloudFormation naming and Fargate profile names do not allow dots in the name. Therefore, `product_version` cannot be used directly to differentiate resources.
- Removed the node group.

## Related PRs
- [4.4.0] - https://github.com/wso2/apim-test-integration/pull/310
- [4.3.0] - https://github.com/wso2/apim-test-integration/pull/311
- [4.2.0] - https://github.com/wso2/apim-test-integration/pull/312
- [4.1.0] - https://github.com/wso2/apim-test-integration/pull/313
- [4.0.0] - https://github.com/wso2/apim-test-integration/pull/314
- [3.2.1] - https://github.com/wso2/apim-test-integration/pull/316
- [3.2.0] - https://github.com/wso2/apim-test-integration/pull/315
