### PR TITLE
[apim-main] Update MySQL version to 8.0.39 in integration scripts

### DIFF
--- a/integration-ui.groovy
+++ b/integration-ui.groovy
@@ -65,7 +65,7 @@ String apimPackDirectory = "wso2am"
 String githubCredentialId = "WSO2_GITHUB_TOKEN"
 def dbEngineList = [
     "mysql": [
-        version: "8.0.37",
+        version: "8.0.39",
         dbDriver: "com.mysql.cj.jdbc.Driver",
         driverUrl: "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.29/mysql-connector-java-8.0.29.jar",
         dbType: "mysql",

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -65,7 +65,7 @@ String apimPackDirectory = "wso2am"
 String githubCredentialId = "WSO2_GITHUB_TOKEN"
 def dbEngineList = [
     "mysql": [
-        version: "8.0.37",
+        version: "8.0.39",
         dbDriver: "com.mysql.cj.jdbc.Driver",
         driverUrl: "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.29/mysql-connector-java-8.0.29.jar",
         dbType: "mysql",


### PR DESCRIPTION
This pull request updates the MySQL database version used in two integration pipeline files to ensure compatibility with the latest MySQL release.

Database version update:

* Updated the MySQL version from `8.0.37` to `8.0.39` in the `dbEngineList` configuration of `integration-ui.groovy` to use the latest stable release.
* Updated the MySQL version from `8.0.37` to `8.0.39` in the `dbEngineList` configuration of `integration-v2.groovy` for consistency across integration pipelines.

- Fixes: https://github.com/wso2/testgrid-jenkins-library/issues/283