### PR TITLE
[apim-main]  Update MySQL version to 8.0.43 in integration script

### DIFF
--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -65,7 +65,7 @@ String apimPackDirectory = "wso2am"
 String githubCredentialId = "WSO2_GITHUB_TOKEN"
 def dbEngineList = [
     "mysql": [
-        version: "8.0.39",
+        version: "8.0.43",
         dbDriver: "com.mysql.cj.jdbc.Driver",
         driverUrl: "https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.29/mysql-connector-java-8.0.29.jar",
         dbType: "mysql",


### PR DESCRIPTION
This pull request updates the MySQL database version used in integration script.

Database version update:

- Updated the MySQL version from 8.0.39 to 8.0.43 in the `dbEngineList` configuration of `integration-ui.groovy`.

Related PR:
- https://github.com/wso2/testgrid-jenkins-library/pull/284