### PR TITLE
Add Peer Test Support

### DIFF
--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -932,6 +932,12 @@ pipeline {
                                                             echo "DCR endpoint not ready yet. Waiting 10s..."
                                                             sleep 10
                                                         done
+
+                                                        # After retry loop: fail explicitly if endpoint never became ready
+                                                        if ! [[ "\$STATUS" =~ ^[234] ]]; then
+                                                            echo "ERROR: DCR endpoint did not become ready after 30 attempts. Aborting tests."
+                                                            exit 1
+                                                        fi
                                                     """
 
                                                     sh """

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -748,8 +748,6 @@ pipeline {
                                                     String wso2amTmImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-tm --query 'imageDetails[?contains(imageTags, `${tmImageTag}`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
                                                     String wso2amGwImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-universal-gw --query 'imageDetails[?contains(imageTags, `${gwImageTag}`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
 
-                                                    sleep 60
-
                                                     // Execute DB scripts with per-pattern database names
                                                     executeDBScripts(dbEngineNameSafe, endpoint, dbUser, dbPassword, "${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}", dbSuffix)
 

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -626,7 +626,7 @@ pipeline {
                         return
                     }
                     
-                    // Pre-download APIM pack for each infra pattern (avoids race condition in parallel tasks)
+                    // Download APIM pack once (only needed for DB scripts and keystores)
                     withCredentials([
                         [
                             $class: 'AmazonWebServicesCredentialsBinding',
@@ -635,18 +635,18 @@ pipeline {
                             secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
                         ]
                     ]) {
+                        sh """
+                            if [ ! -d "./${apimPackDirectory}/${product}-${productVersion}" ]; then
+                                aws s3 cp --quiet s3://${apimPackS3Bucket}/packs/${product}-${productVersion}.zip .
+                                unzip -o ${product}-${productVersion}.zip -d ./${apimPackDirectory}
+                                ls -la ./${apimPackDirectory}/${product}-${productVersion}/
+                            else
+                                echo "APIM pack already downloaded."
+                            fi
+                        """
+                        // Copy the extracted pack into each pattern directory so deploy stages can reference it
                         for (def pattern : deploymentPatterns) {
-                            dir("${pattern.directory}") {
-                                sh """
-                                    if [ ! -d "./${apimPackDirectory}/${product}-${productVersion}" ]; then
-                                        aws s3 cp --quiet s3://${apimPackS3Bucket}/packs/${product}-${productVersion}.zip .
-                                        unzip -o ${product}-${productVersion}.zip -d ./${apimPackDirectory}
-                                        ls -la ./${apimPackDirectory}/${product}-${productVersion}/
-                                    else
-                                        echo "APIM pack already downloaded."
-                                    fi
-                                """
-                            }
+                            sh "cp -r ./${apimPackDirectory} ${pattern.directory}/"
                         }
                     }
 

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -146,14 +146,19 @@ def createDeploymentPatterns(String project, String product, String productVersi
     }
 }
 
+def getDbNames(String dbSuffix) {
+    String sharedDbName = dbSuffix ? "shared_db_${dbSuffix}" : "shared_db"
+    String apimDbName   = dbSuffix ? "apim_db_${dbSuffix}"   : "apim_db"
+    return [sharedDbName, apimDbName]
+}
+
 /**
  * Execute DB scripts to create and initialise databases.
  * @param dbSuffix  Suffix for unique DB names per test pattern (e.g. "all_staging").
  *                  Use empty string "" for single-pattern / custom mode (names stay shared_db, apim_db).
  */
 def executeDBScripts(String dbEngine, String dbEndpoint, String dbUser, String dbPassword, String scriptPath, String dbSuffix) {
-    String sharedDbName = dbSuffix ? "shared_db_${dbSuffix}" : "shared_db"
-    String apimDbName   = dbSuffix ? "apim_db_${dbSuffix}"   : "apim_db"
+    def (sharedDbName, apimDbName) = getDbNames(dbSuffix)
     println "Executing DB scripts for ${dbEngine} at ${dbEndpoint} (databases: ${sharedDbName}, ${apimDbName})..."
 
     try {
@@ -713,8 +718,7 @@ pipeline {
                                                     // Namespace includes peer test pattern name for isolation
                                                     def namespace = (peerTestPatterns.size() > 1) ? "${patternSafe.id}-${dbEngineNameSafe}-${dpName}" : "${patternSafe.id}-${dbEngineNameSafe}"
                                                     // Unique DB names for this peer test pattern
-                                                    String sharedDbName = dbSuffix ? "shared_db_${dbSuffix}" : "shared_db"
-                                                    String apimDbName   = dbSuffix ? "apim_db_${dbSuffix}"   : "apim_db"
+                                                    def (sharedDbName, apimDbName) = getDbNames(dbSuffix)
 
                                                     // Hostnames include peer test pattern name when running multiple patterns
                                                     def hostSuffix = (peerTestPatterns.size() > 1) ? "${dbEngineNameSafe}-${dpName}" : "${dbEngineNameSafe}"
@@ -748,7 +752,6 @@ pipeline {
                                                     String wso2amTmImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-tm --query 'imageDetails[?contains(imageTags, `${tmImageTag}`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
                                                     String wso2amGwImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-universal-gw --query 'imageDetails[?contains(imageTags, `${gwImageTag}`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
 
-                                                    sleep 60
 
                                                     // Execute DB scripts with per-pattern database names
                                                     executeDBScripts(dbEngineNameSafe, endpoint, dbUser, dbPassword, "${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}", dbSuffix)

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -44,9 +44,35 @@ Boolean skipTfApply = params.skipTfApply
 Boolean skipDockerBuild = params.skipDockerBuild
 Boolean skipTests = params.skipTests
 Boolean skipUpdate = params.skipUpdate ?: false
+Boolean skipPeerTest = params.skipPeerTest ?: false
 
 // Default values
 def deploymentPatterns = []
+// ============================================================================
+// PEER TEST DEPLOYMENT PATTERNS
+// ============================================================================
+// skipPeerTest=false (default): All 4 peer test patterns run in parallel:
+//   Pattern 1: All components on staging (latest update)
+//   Pattern 2: Only ACP on staging, TM and GW on GA
+//   Pattern 3: Only TM on staging, ACP and GW on GA
+//   Pattern 4: Only GW on staging, ACP and TM on GA
+// skipPeerTest=true: A single custom pattern is used.
+// ============================================================================
+def peerTestPatterns = []
+int nodesPerNamespace = 5
+
+if (!skipPeerTest) {
+    peerTestPatterns = [
+        [name: "all-staging", acpVariant: "latest", tmVariant: "latest", gwVariant: "latest"],
+        [name: "acp-staging", acpVariant: "latest", tmVariant: "ga",     gwVariant: "ga"],
+        [name: "tm-staging",  acpVariant: "ga",     tmVariant: "latest", gwVariant: "ga"],
+        [name: "gw-staging",  acpVariant: "ga",     tmVariant: "ga",     gwVariant: "latest"],
+    ]
+} else {
+    peerTestPatterns = [
+        [name: "custom", acpVariant: "latest", tmVariant: "latest", gwVariant: "latest"],
+    ]
+}
 String updateType = "u2"
 String hostName = ""
 String dbUser = "wso2carbon"
@@ -83,7 +109,8 @@ def dbEngineList = [
 // Create deployment patterns for all combinations of OS and database
 @NonCPS
 def createDeploymentPatterns(String project, String product, String productVersion, 
-                                String[] osList, String[] databaseList, def dbEngineList, def deploymentPatterns) {
+                                String[] osList, String[] databaseList, def dbEngineList, def deploymentPatterns,
+                                int nodesPerNamespace, int peerTestPatternCount) {
     println "Creating the deployment patterns by using infrastructure combination!"
     
     int count = 1
@@ -112,14 +139,22 @@ def createDeploymentPatterns(String project, String product, String productVersi
             dbEngines: dbEngines,
             dbEnginesJson: dbEnginesJson,
             directory: deploymentDirName,
-            eksDesiredSize: 5*dbEngines.size(),
+            // Scale EKS nodes to handle all peer test patterns running in parallel
+            eksDesiredSize: nodesPerNamespace * dbEngines.size() * peerTestPatternCount,
         ]
         deploymentPatterns.add(deploymentPattern)
     }
 }
 
-def executeDBScripts(String dbEngine, String dbEndpoint, String dbUser, String dbPassword, String scriptPath) {
-    println "Executing DB scripts for ${dbEngine} at ${dbEndpoint}..."
+/**
+ * Execute DB scripts to create and initialise databases.
+ * @param dbSuffix  Suffix for unique DB names per test pattern (e.g. "all_staging").
+ *                  Use empty string "" for single-pattern / custom mode (names stay shared_db, apim_db).
+ */
+def executeDBScripts(String dbEngine, String dbEndpoint, String dbUser, String dbPassword, String scriptPath, String dbSuffix) {
+    String sharedDbName = dbSuffix ? "shared_db_${dbSuffix}" : "shared_db"
+    String apimDbName   = dbSuffix ? "apim_db_${dbSuffix}"   : "apim_db"
+    println "Executing DB scripts for ${dbEngine} at ${dbEndpoint} (databases: ${sharedDbName}, ${apimDbName})..."
 
     try {
         timeout(time: 5, unit: 'MINUTES') {
@@ -127,23 +162,23 @@ def executeDBScripts(String dbEngine, String dbEndpoint, String dbUser, String d
                 // Execute MySQL scripts
                 println "Executing MySQL scripts..."
                 sh """
-                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "DROP DATABASE IF EXISTS shared_db;"
-                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "DROP DATABASE IF EXISTS apim_db;"
-                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "CREATE DATABASE IF NOT EXISTS shared_db CHARACTER SET latin1;"
-                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "CREATE DATABASE IF NOT EXISTS apim_db CHARACTER SET latin1;"
-                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -Dshared_db < ${scriptPath}/dbscripts/mysql.sql
-                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -Dapim_db < ${scriptPath}/dbscripts/apimgt/mysql.sql
+                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "DROP DATABASE IF EXISTS ${sharedDbName};"
+                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "DROP DATABASE IF EXISTS ${apimDbName};"
+                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "CREATE DATABASE IF NOT EXISTS ${sharedDbName} CHARACTER SET latin1;"
+                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -e "CREATE DATABASE IF NOT EXISTS ${apimDbName} CHARACTER SET latin1;"
+                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -D${sharedDbName} < ${scriptPath}/dbscripts/mysql.sql
+                    mysql -h ${dbEndpoint} -u ${dbUser} -p$dbPassword -D${apimDbName} < ${scriptPath}/dbscripts/apimgt/mysql.sql
                 """
             } else if (dbEngine == "postgres") {
                 // Execute PostgreSQL scripts
                 println "Executing PostgreSQL scripts..."
                 sh """
-                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "DROP DATABASE IF EXISTS shared_db;"
-                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "DROP DATABASE IF EXISTS apim_db;"
-                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "CREATE DATABASE shared_db;"
-                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "CREATE DATABASE apim_db;"
-                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d shared_db -f ${scriptPath}/dbscripts/postgresql.sql
-                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d apim_db -f ${scriptPath}/dbscripts/apimgt/postgresql.sql
+                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "DROP DATABASE IF EXISTS ${sharedDbName};"
+                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "DROP DATABASE IF EXISTS ${apimDbName};"
+                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "CREATE DATABASE ${sharedDbName};"
+                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d postgres -c "CREATE DATABASE ${apimDbName};"
+                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d ${sharedDbName} -f ${scriptPath}/dbscripts/postgresql.sql
+                    PGPASSWORD=$dbPassword psql -h ${dbEndpoint} -U ${dbUser} -d ${apimDbName} -f ${scriptPath}/dbscripts/apimgt/postgresql.sql
                 """
             } else {
                 error "Unsupported DB engine: ${dbEngine}"
@@ -315,7 +350,11 @@ pipeline {
                 script {
                     println "OS List: ${osList}"
                     println "Database List: ${databaseList}"
-                    createDeploymentPatterns(project, product, productVersion, osList, databaseList, dbEngineList, deploymentPatterns)
+                    println "Skip Peer Test: ${skipPeerTest}"
+                    println "Peer Test Patterns: ${peerTestPatterns.collect { it.name }}"
+                    println "Update Levels — ACP: ${acpUpdateLevel}, TM: ${tmUpdateLevel}, GW: ${gwUpdateLevel}"
+                    createDeploymentPatterns(project, product, productVersion, osList, databaseList, dbEngineList, deploymentPatterns,
+                                            nodesPerNamespace, peerTestPatterns.size())
 
                     println "Deployment patterns created: ${deploymentPatterns}"
 
@@ -522,18 +561,52 @@ pipeline {
                             def dockerRegistryUsername = pattern.dockerRegistry.username
                             def dockerRegistryPassword = pattern.dockerRegistry.password
                             
-                            parallelBuilds["Build ${currentOs}-${db} wso2am-acp image"] = {
-                                buildDockerImage(project, "wso2am-acp", productVersion, currentOs, acpUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
-                            }
-                            parallelBuilds["Build ${currentOs}-${db} wso2am-tm image"] = {
-                                buildDockerImage(project, "wso2am-tm", productVersion, currentOs, tmUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
-                            }
-                            parallelBuilds["Build ${currentOs}-${db} wso2am-universal-gw image"] = {
-                                buildDockerImage(project, "wso2am-universal-gw", productVersion, currentOs, gwUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
+                            if (!skipPeerTest) {
+                                // ============================================================
+                                // PEER TEST MODE: Build 6 unique images per DB
+                                //   3 apps x 2 variants (latest, ga)
+                                //   Tags: {db}-latest  (updated version, user-provided update levels)
+                                //         {db}-ga      (initial version, update level 0)
+                                // ============================================================
+                                // Build "latest" variant — updated version with user-provided update levels
+                                parallelBuilds["Build ${currentOs}-${db}-latest wso2am-acp"] = {
+                                    buildDockerImage(project, "wso2am-acp", productVersion, currentOs, acpUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
+                                }
+                                parallelBuilds["Build ${currentOs}-${db}-latest wso2am-tm"] = {
+                                    buildDockerImage(project, "wso2am-tm", productVersion, currentOs, tmUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
+                                }
+                                parallelBuilds["Build ${currentOs}-${db}-latest wso2am-universal-gw"] = {
+                                    buildDockerImage(project, "wso2am-universal-gw", productVersion, currentOs, gwUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
+                                }
+                                // Build "ga" variant — initial version (update level 0, no updates applied)
+                                parallelBuilds["Build ${currentOs}-${db}-ga wso2am-acp"] = {
+                                    buildDockerImage(project, "wso2am-acp", productVersion, currentOs, "0", "${db}-ga", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, false)
+                                }
+                                parallelBuilds["Build ${currentOs}-${db}-ga wso2am-tm"] = {
+                                    buildDockerImage(project, "wso2am-tm", productVersion, currentOs, "0", "${db}-ga", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, false)
+                                }
+                                parallelBuilds["Build ${currentOs}-${db}-ga wso2am-universal-gw"] = {
+                                    buildDockerImage(project, "wso2am-universal-gw", productVersion, currentOs, "0", "${db}-ga", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, false)
+                                }
+                            } else {
+                                // ============================================================
+                                // CUSTOM MODE: Build 3 images using user-provided update levels
+                                //   Tag: {db}-latest (same as original v2 behaviour)
+                                // ============================================================
+                                parallelBuilds["Build ${currentOs}-${db} wso2am-acp image"] = {
+                                    buildDockerImage(project, "wso2am-acp", productVersion, currentOs, acpUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
+                                }
+                                parallelBuilds["Build ${currentOs}-${db} wso2am-tm image"] = {
+                                    buildDockerImage(project, "wso2am-tm", productVersion, currentOs, tmUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
+                                }
+                                parallelBuilds["Build ${currentOs}-${db} wso2am-universal-gw image"] = {
+                                    buildDockerImage(project, "wso2am-universal-gw", productVersion, currentOs, gwUpdateLevel, "${db}-latest", dbDriverUrl, dockerRegistry, dockerRegistryUsername, dockerRegistryPassword, useStaging, skipUpdate)
+                                }
                             }
                         }
                     }
                     
+                    println "Total docker builds: ${parallelBuilds.size()} (skipPeerTest=${skipPeerTest})"
                     // Execute all builds in parallel
                     parallel parallelBuilds
                 }
@@ -548,294 +621,358 @@ pipeline {
                         return
                     }
                     
-                    // Create a map of parallel deployment tasks
+                    // Pre-download APIM pack for each infra pattern (avoids race condition in parallel tasks)
+                    withCredentials([
+                        [
+                            $class: 'AmazonWebServicesCredentialsBinding',
+                            credentialsId: awsCred,
+                            accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                            secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                        ]
+                    ]) {
+                        for (def pattern : deploymentPatterns) {
+                            dir("${pattern.directory}") {
+                                sh """
+                                    if [ ! -d "./${apimPackDirectory}/${product}-${productVersion}" ]; then
+                                        aws s3 cp --quiet s3://${apimPackS3Bucket}/packs/${product}-${productVersion}.zip .
+                                        unzip -o ${product}-${productVersion}.zip -d ./${apimPackDirectory}
+                                        ls -la ./${apimPackDirectory}/${product}-${productVersion}/
+                                    else
+                                        echo "APIM pack already downloaded."
+                                    fi
+                                """
+                            }
+                        }
+                    }
+
+                    // ====================================================================
+                    // Deploy and test all combinations in parallel
+                    //   skipPeerTest=false : Deploys all 4 peer test patterns per infra
+                    //   skipPeerTest=true  : Deploys a single pattern per infra (original)
+                    //
+                    //   Each peer test pattern runs in its own K8s namespace with its own
+                    //   DB names and hostnames to avoid collisions.
+                    // ====================================================================
                     def parallelDeployments = [:]
                     
-                    // Add each deployment as a parallel task
                     for (def pattern : deploymentPatterns) {
                         def patternDir = pattern.directory
-                        for (def dbEngine : pattern.dbEngines) {
-                            def dbEngineName = dbEngine.engine
-                            
-                            // We need to use variables that are safe for the closure
-                            def patternDirSafe = patternDir
-                            def dbEngineNameSafe = dbEngineName
-                            def patternSafe = pattern
-                            def dockerRegistrySafe = pattern.dockerRegistry.registry
-                            def dockerRegistryUsernameSafe = pattern.dockerRegistry.username
-                            def dockerRegistryPasswordSafe = pattern.dockerRegistry.password
-                            def stageId = "${patternDirSafe}-${dbEngineNameSafe}"
-                            
-                            // Add deployment task to parallel map
-                            parallelDeployments["Deploy ${stageId}"] = {
-                                stage("Deploy ${stageId}") {
-                                    try {
-                                        withCredentials([
-                                            [
-                                                $class: 'AmazonWebServicesCredentialsBinding',
-                                                credentialsId: awsCred,
-                                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                            ]
-                                        ]) {
-                                            String pwd = sh(script: "pwd", returnStdout: true).trim()
-                                            // Login to Docker registry
-                                            sh """
-                                                echo ${dockerRegistryPasswordSafe} | sudo docker login ${dockerRegistrySafe} --username ${dockerRegistryUsernameSafe} --password-stdin
-                                            """
+                        for (def tp : peerTestPatterns) {
+                            for (def dbEngine : pattern.dbEngines) {
+                                def dbEngineName = dbEngine.engine
+                                
+                                // Capture variables for closure safety
+                                def patternDirSafe = patternDir
+                                def dbEngineNameSafe = dbEngineName
+                                def patternSafe = pattern
+                                def dockerRegistrySafe = pattern.dockerRegistry.registry
+                                def dockerRegistryUsernameSafe = pattern.dockerRegistry.username
+                                def dockerRegistryPasswordSafe = pattern.dockerRegistry.password
+                                def dpSafe = tp
+                                def dpName = tp.name
 
-                                            dir("${patternDirSafe}") {
-                                                // Copy APIM pack from S3 bucket
+                                // Unique stage identifier including peer test pattern name
+                                def stageId = "${patternDirSafe}-${dbEngineNameSafe}-${dpName}"
+                                // DB suffix for unique database names. Empty for custom single-pattern mode.
+                                def dbSuffix = (peerTestPatterns.size() > 1) ? dpName.replace('-', '_') : ""
+
+                                // Determine the docker image tag for each component based on peer test pattern
+                                def acpImageTag = "${dbEngineNameSafe}-${dpSafe.acpVariant}"  // e.g. mysql-latest or mysql-ga
+                                def tmImageTag  = "${dbEngineNameSafe}-${dpSafe.tmVariant}"
+                                def gwImageTag  = "${dbEngineNameSafe}-${dpSafe.gwVariant}"
+                                
+                                // Add deployment task to parallel map
+                                parallelDeployments["Deploy ${stageId}"] = {
+                                    stage("Deploy ${stageId}") {
+                                        try {
+                                            withCredentials([
+                                                [
+                                                    $class: 'AmazonWebServicesCredentialsBinding',
+                                                    credentialsId: awsCred,
+                                                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                                ]
+                                            ]) {
+                                                String pwd = sh(script: "pwd", returnStdout: true).trim()
+                                                // Login to Docker registry
                                                 sh """
-                                                    aws s3 cp --quiet s3://${apimPackS3Bucket}/packs/${product}-${productVersion}.zip .
-                                                    unzip ${product}-${productVersion}.zip -d ./${apimPackDirectory}
-                                                    ls -la ./${apimPackDirectory}/${product}-${productVersion}/
+                                                    echo ${dockerRegistryPasswordSafe} | sudo docker login ${dockerRegistrySafe} --username ${dockerRegistryUsernameSafe} --password-stdin
                                                 """
 
-
-                                                def dbWriterEndpointsJson = sh(script: "terraform output -json | jq -r '.database_writer_endpoints.value'", returnStdout: true).trim()
-                                                def dbWriterEndpoints = new groovy.json.JsonSlurperClassic().parseText(dbWriterEndpointsJson)
-                                                if (!dbWriterEndpoints) {
-                                                    error "DB Writer Endpoints are null or empty for ${patternDirSafe}. Please check the Terraform output."
-                                                }
-                                                println "DB Writer Endpoints: ${dbWriterEndpoints}"
-                                                // Convert LazyMap to HashMap
-                                                patternSafe.dbEndpoints = new HashMap<>(dbWriterEndpoints)
-
-                                                def (endpoint, dbPort) = patternSafe.dbEndpoints["${dbEngineNameSafe}-${dbEngineList[dbEngineNameSafe].version}"]?.tokenize(':')
-                                                def namespace = "${patternSafe.id}-${dbEngineNameSafe}"
-                                                sh """
-                                                    # Change context
-                                                    kubectl config use-context ${patternDirSafe}
-
-                                                    # Create a namespace for the deployment
-                                                    kubectl create namespace ${namespace} || echo "Namespace ${namespace} already exists."
-
-                                                    # Create apim-keystore-secret
-                                                    kubectl create secret generic apim-keystore-secret --from-file=${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}/repository/resources/security/wso2carbon.jks --from-file=${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}/repository/resources/security/client-truststore.jks -n ${namespace} || echo "Failed to create apim-keystore-secret."
-                                                """
-                                                println "Namespace created: ${namespace}"
-
-                                                sh """
-                                                # Delete existing release if it exists
-                                                helm list -n ${namespace} -q | xargs -n1 -I{} helm uninstall {} -n ${namespace} || echo "Failed to delete existing release."
-
-                                                # Delete gateway REST ingress if it exists
-                                                kubectl delete ingress gw-rest-ingress -n ${namespace} || echo "Skipped deleting existing ingress."
-                                                """
-
-                                                String wso2amAcpImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-acp --query 'imageDetails[?contains(imageTags, `${dbEngineNameSafe}-latest`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
-                                                String wso2amTmImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-tm --query 'imageDetails[?contains(imageTags, `${dbEngineNameSafe}-latest`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
-                                                String wso2amGwImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-universal-gw --query 'imageDetails[?contains(imageTags, `${dbEngineNameSafe}-latest`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
-
-                                                sleep 60
-
-                                                // Execute DB scripts
-                                                executeDBScripts(dbEngineNameSafe, endpoint, dbUser, dbPassword, "${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}")
-
-                                                String helmChartPath = "${pwd}/${helmDirectory}"
-                                                // Install the product using Helm
-                                                sh """
-                                                    # Helm-apim does not have a ingress to expose gateway REST API. So we need to create a ingress resource to expose the REST API.
-                                                    helm install apim-ing ${pwd}/${apimIntgDirectory}/kubernetes/gw-ingress \
-                                                        --set hostname=gw-${dbEngineNameSafe}.wso2.com \
-                                                        --namespace ${namespace}
-                                                    
-                                                    # Deploy wso2am-acp
-                                                    echo "Deploying WSO2 API Manager - API Control Plane in ${namespace} namespace..."
-                                                    helm install apim-acp ${helmChartPath}/distributed/control-plane \
-                                                        --namespace ${namespace} \
-                                                        --set aws.enabled=false \
-                                                        --set wso2.apim.configurations.adminUsername="admin" \
-                                                        --set wso2.apim.configurations.adminPassword="admin" \
-                                                        --set wso2.apim.configurations.security.keystores.primary.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.primary.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.tls.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.tls.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.internal.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.internal.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.truststore.password="wso2carbon" \
-                                                        --set wso2.deployment.resources.requests.cpu="1000m" \
-                                                        --set wso2.apim.configurations.userStore.properties.ReadGroups=true \
-                                                        --set kubernetes.ingress.controlPlane.hostname="am-${dbEngineNameSafe}.wso2.com" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].name="Default" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].type="hybrid" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].gatewayType="Regular" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].provider="wso2" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].displayInApiConsole=true \
-                                                        --set wso2.apim.configurations.gateway.environments[0].description="This is a hybrid gateway that handles both production and sandbox token traffic." \
-                                                        --set wso2.apim.configurations.gateway.environments[0].showAsTokenEndpointUrl=true \
-                                                        --set wso2.apim.configurations.gateway.environments[0].serviceName="apim-universal-gw-wso2am-universal-gw-service" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].servicePort=9443 \
-                                                        --set wso2.apim.configurations.gateway.environments[0].wsHostname="websocket-${dbEngineNameSafe}.wso2.com" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].httpHostname="gw-${dbEngineNameSafe}.wso2.com" \
-                                                        --set wso2.apim.configurations.gateway.environments[0].websubHostname="websub-${dbEngineNameSafe}.wso2.com" \
-                                                        --set wso2.apim.configurations.devportal.enableApplicationSharing=true \
-                                                        --set wso2.apim.configurations.devportal.applicationSharingType="default" \
-                                                        --set wso2.apim.configurations.oauth_config.oauth2JWKSUrl="https://apim-acp-wso2am-acp-service:9443/oauth2/jwks" \
-                                                        --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
-                                                        --set wso2.deployment.image.repository="${project}-wso2am-acp:${dbEngineNameSafe}-latest" \
-                                                        --set wso2.deployment.image.digest="${wso2amAcpImageDigest}" \
-                                                        --set wso2.deployment.image.imagePullSecrets.enabled=true \
-                                                        --set wso2.deployment.image.imagePullSecrets.username="${dockerRegistryUsernameSafe}" \
-                                                        --set wso2.deployment.image.imagePullSecrets.password="${dockerRegistryPasswordSafe}" \
-                                                        --set wso2.apim.configurations.databases.type="${dbEngineList[dbEngineNameSafe].dbType}" \
-                                                        --set wso2.apim.configurations.databases.jdbc.driver="${dbEngineList[dbEngineNameSafe].dbDriver}" \
-                                                        --set wso2.apim.configurations.databases.apim_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/apim_db?useSSL=false" \
-                                                        --set wso2.apim.configurations.databases.apim_db.username="${dbUser}" \
-                                                        --set wso2.apim.configurations.databases.apim_db.password="${dbPassword}" \
-                                                        --set wso2.apim.configurations.databases.shared_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/shared_db?useSSL=false" \
-                                                        --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
-                                                        --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}"
-                                                    
-                                                    # Wait for the deployment to be ready
-                                                    kubectl wait --for=condition=available --timeout=400s deployment/apim-acp-wso2am-acp-deployment-1 -n ${namespace}
-
-                                                    # Deploy wso2am-tm
-                                                    echo "Deploying WSO2 API Manager - Traffic Manager in ${namespace} namespace..."
-                                                    helm install apim-tm ${helmChartPath}/distributed/traffic-manager \
-                                                        --namespace ${namespace} \
-                                                        --set aws.enabled=false \
-                                                        --set wso2.apim.configurations.adminUsername="admin" \
-                                                        --set wso2.apim.configurations.adminPassword="admin" \
-                                                        --set wso2.apim.configurations.security.keystores.primary.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.primary.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.tls.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.tls.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.internal.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.internal.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.truststore.password="wso2carbon" \
-                                                        --set wso2.deployment.resources.requests.cpu="1000m" \
-                                                        --set wso2.apim.configurations.km.serviceUrl="apim-acp-wso2am-acp-service" \
-                                                        --set wso2.apim.configurations.eventhub.enabled=true \
-                                                        --set wso2.apim.configurations.eventhub.serviceUrl="apim-acp-wso2am-acp-service" \
-                                                        --set wso2.apim.configurations.eventhub.urls="{apim-acp-wso2am-acp-1-service,apim-acp-wso2am-acp-2-service}" \
-                                                        --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
-                                                        --set wso2.deployment.image.repository="${project}-wso2am-tm:${dbEngineNameSafe}-latest" \
-                                                        --set wso2.deployment.image.digest=${wso2amTmImageDigest} \
-                                                        --set wso2.deployment.image.imagePullSecrets.enabled=true \
-                                                        --set wso2.deployment.image.imagePullSecrets.username="${dockerRegistryUsernameSafe}" \
-                                                        --set wso2.deployment.image.imagePullSecrets.password="${dockerRegistryPasswordSafe}" \
-                                                        --set wso2.apim.configurations.databases.type="${dbEngineList[dbEngineNameSafe].dbType}" \
-                                                        --set wso2.apim.configurations.databases.jdbc.driver="${dbEngineList[dbEngineNameSafe].dbDriver}" \
-                                                        --set wso2.apim.configurations.databases.apim_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/apim_db?useSSL=false" \
-                                                        --set wso2.apim.configurations.databases.apim_db.username="${dbUser}" \
-                                                        --set wso2.apim.configurations.databases.apim_db.password="${dbPassword}" \
-                                                        --set wso2.apim.configurations.databases.shared_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/shared_db?useSSL=false" \
-                                                        --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
-                                                        --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}"
-
-                                                    # Wait for the deployment to be ready
-                                                    kubectl wait --for=condition=available --timeout=400s deployment/apim-tm-wso2am-tm-deployment-1 -n ${namespace}
-
-                                                    # Deploy wso2am-gw
-                                                    echo "Deploying WSO2 API Manager - Gateway in ${namespace} namespace..."
-                                                    helm install apim-universal-gw ${helmChartPath}/distributed/gateway \
-                                                        --namespace ${namespace} \
-                                                        --set aws.enabled=false \
-                                                        --set wso2.apim.configurations.adminUsername="admin" \
-                                                        --set wso2.apim.configurations.adminPassword="admin" \
-                                                        --set wso2.apim.configurations.security.keystores.primary.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.primary.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.tls.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.tls.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.internal.password="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.keystores.internal.keyPassword="wso2carbon" \
-                                                        --set wso2.apim.configurations.security.truststore.password="wso2carbon" \
-                                                        --set wso2.deployment.resources.requests.cpu="1000m" \
-                                                        --set kubernetes.ingress.gateway.hostname="gw-${dbEngineNameSafe}.wso2.com" \
-                                                        --set kubernetes.ingress.websocket.hostname="websocket-${dbEngineNameSafe}.wso2.com" \
-                                                        --set kubernetes.ingress.websub.hostname="websub-${dbEngineNameSafe}.wso2.com" \
-                                                        --set wso2.apim.configurations.km.serviceUrl="apim-acp-wso2am-acp-service" \
-                                                        --set wso2.apim.configurations.throttling.serviceUrl="apim-tm-wso2am-tm-service" \
-                                                        --set wso2.apim.configurations.throttling.urls="{apim-tm-wso2am-tm-1-service,apim-tm-wso2am-tm-2-service}" \
-                                                        --set wso2.apim.configurations.eventhub.enabled=true \
-                                                        --set wso2.apim.configurations.eventhub.serviceUrl="apim-acp-wso2am-acp-service" \
-                                                        --set wso2.apim.configurations.eventhub.urls="{apim-acp-wso2am-acp-1-service,apim-acp-wso2am-acp-2-service}" \
-                                                        --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
-                                                        --set wso2.deployment.image.repository="${project}-wso2am-universal-gw:${dbEngineNameSafe}-latest" \
-                                                        --set wso2.deployment.image.digest=${wso2amGwImageDigest} \
-                                                        --set wso2.deployment.image.imagePullSecrets.enabled=true \
-                                                        --set wso2.deployment.image.imagePullSecrets.username="${dockerRegistryUsernameSafe}" \
-                                                        --set wso2.deployment.image.imagePullSecrets.password="${dockerRegistryPasswordSafe}" \
-                                                        --set wso2.apim.configurations.databases.type="${dbEngineList[dbEngineNameSafe].dbType}" \
-                                                        --set wso2.apim.configurations.databases.jdbc.driver="${dbEngineList[dbEngineNameSafe].dbDriver}" \
-                                                        --set wso2.apim.configurations.databases.shared_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/shared_db?useSSL=false" \
-                                                        --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
-                                                        --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}" \
-                                                        --set wso2.deployment.replicas=2 \
-                                                        --set wso2.deployment.minReplicas=2
-                                                    
-                                                    # Wait for the deployment to be ready
-                                                    kubectl wait --for=condition=ready --timeout=300s pod -l deployment=apim-universal-gw-wso2am-universal-gw -n ${namespace}
-                                                """
-                                            }
-                                        }
-                                    } catch (Exception e) {
-                                        println "Deployment failed for ${patternDirSafe}-${dbEngineNameSafe}: ${e}"
-                                        error "Deployment failed for ${patternDirSafe}-${dbEngineNameSafe}. Please check the logs for more details."
-                                    }
-                                }
-
-                                stage("Test ${stageId}") {
-                                    if (skipTests) {
-                                        echo "Skipping tests for ${stageId} as skipTests is set to true."
-                                        return
-                                    }
-                                    try {
-                                        withCredentials([
-                                            [
-                                                $class: 'AmazonWebServicesCredentialsBinding',
-                                                credentialsId: awsCred,
-                                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                            ]
-                                        ]) {
-                                            String namespace = "${patternSafe.id}-${dbEngineNameSafe}"
-                                            dir("${apimIntgDirectory}") {
-                                                sh """
-                                                    # Change context
-                                                    kubectl config use-context ${patternDirSafe}
-                                                """
-
-                                                echo "Waiting 60 seconds before proceeding with tests for ${patternDirSafe} with ${dbEngineNameSafe}..."
-                                                sleep 60
-
-                                                sh """
-                                                    ./main.sh --HOSTNAME="${patternSafe.hostName}" \
-                                                        --PORTAL_HOST="am-${dbEngineNameSafe}.wso2.com" \
-                                                        --GATEWAY_HOST="gw-${dbEngineNameSafe}.wso2.com" \
-                                                        --kubernetes_namespace="${namespace}"
-                                                """
-                                            }
-
-                                            dir("${logsDirectory}") {
-                                                def podNames = sh(
-                                                    script: "kubectl get pods -l product=apim -n=${namespace} -o custom-columns=:metadata.name",
-                                                    returnStdout: true
-                                                ).trim().split('\n')
-                                                println "APIM pods in namespace ${namespace}: ${podNames}"
-                                                for (def podName : podNames) {
-                                                    if (podName?.trim()) {
-                                                        def logFile = "${dbEngineNameSafe}-${podName}.log"
-                                                        sh """
-                                                            kubectl logs ${podName} -n=${namespace} > ${logFile} || echo "Failed to get logs for pod ${podName}"
-                                                        """
+                                                dir("${patternDirSafe}") {
+                                                    def dbWriterEndpointsJson = sh(script: "terraform output -json | jq -r '.database_writer_endpoints.value'", returnStdout: true).trim()
+                                                    def dbWriterEndpoints = new groovy.json.JsonSlurperClassic().parseText(dbWriterEndpointsJson)
+                                                    if (!dbWriterEndpoints) {
+                                                        error "DB Writer Endpoints are null or empty for ${patternDirSafe}. Please check the Terraform output."
                                                     }
+                                                    println "DB Writer Endpoints: ${dbWriterEndpoints}"
+                                                    // Convert LazyMap to HashMap
+                                                    patternSafe.dbEndpoints = new HashMap<>(dbWriterEndpoints)
+
+                                                    def (endpoint, dbPort) = patternSafe.dbEndpoints["${dbEngineNameSafe}-${dbEngineList[dbEngineNameSafe].version}"]?.tokenize(':')
+                                                    // Namespace includes peer test pattern name for isolation
+                                                    def namespace = (peerTestPatterns.size() > 1) ? "${patternSafe.id}-${dbEngineNameSafe}-${dpName}" : "${patternSafe.id}-${dbEngineNameSafe}"
+                                                    // Unique DB names for this peer test pattern
+                                                    String sharedDbName = dbSuffix ? "shared_db_${dbSuffix}" : "shared_db"
+                                                    String apimDbName   = dbSuffix ? "apim_db_${dbSuffix}"   : "apim_db"
+
+                                                    // Hostnames include peer test pattern name when running multiple patterns
+                                                    def hostSuffix = (peerTestPatterns.size() > 1) ? "${dbEngineNameSafe}-${dpName}" : "${dbEngineNameSafe}"
+                                                    def portalHost = "am-${hostSuffix}.wso2.com"
+                                                    def gwHost     = "gw-${hostSuffix}.wso2.com"
+                                                    def wsHost     = "websocket-${hostSuffix}.wso2.com"
+                                                    def websubHost = "websub-${hostSuffix}.wso2.com"
+
+                                                    sh """
+                                                        # Change context
+                                                        kubectl config use-context ${patternDirSafe}
+
+                                                        # Create a namespace for the deployment
+                                                        kubectl create namespace ${namespace} || echo "Namespace ${namespace} already exists."
+
+                                                        # Create apim-keystore-secret
+                                                        kubectl create secret generic apim-keystore-secret --from-file=${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}/repository/resources/security/wso2carbon.jks --from-file=${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}/repository/resources/security/client-truststore.jks -n ${namespace} || echo "Failed to create apim-keystore-secret."
+                                                    """
+                                                    println "Namespace created: ${namespace}"
+
+                                                    sh """
+                                                    # Delete existing release if it exists
+                                                    helm list -n ${namespace} -q | xargs -n1 -I{} helm uninstall {} -n ${namespace} || echo "Failed to delete existing release."
+
+                                                    # Delete gateway REST ingress if it exists
+                                                    kubectl delete ingress gw-rest-ingress -n ${namespace} || echo "Skipped deleting existing ingress."
+                                                    """
+
+                                                    // Fetch image digests using variant-specific tags
+                                                    String wso2amAcpImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-acp --query 'imageDetails[?contains(imageTags, `${acpImageTag}`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
+                                                    String wso2amTmImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-tm --query 'imageDetails[?contains(imageTags, `${tmImageTag}`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
+                                                    String wso2amGwImageDigest = sh(script: "aws ecr describe-images --repository-name ${project}-wso2am-universal-gw --query 'imageDetails[?contains(imageTags, `${gwImageTag}`)].imageDigest' --region ${productDeploymentRegion} --output text", returnStdout: true).trim()
+
+                                                    sleep 60
+
+                                                    // Execute DB scripts with per-pattern database names
+                                                    executeDBScripts(dbEngineNameSafe, endpoint, dbUser, dbPassword, "${pwd}/${patternDirSafe}/${apimPackDirectory}/${product}-${productVersion}", dbSuffix)
+
+                                                    String helmChartPath = "${pwd}/${helmDirectory}"
+                                                    // Install the product using Helm
+                                                    sh """
+                                                        # Gateway REST ingress
+                                                        helm install apim-ing ${pwd}/${apimIntgDirectory}/kubernetes/gw-ingress \
+                                                            --set hostname=${gwHost} \
+                                                            --namespace ${namespace}
+                                                        
+                                                        # Deploy wso2am-acp (variant: ${dpSafe.acpVariant})
+                                                        echo "Deploying WSO2 API Manager - API Control Plane [${dpSafe.acpVariant}] in ${namespace} namespace..."
+                                                        helm install apim-acp ${helmChartPath}/distributed/control-plane \
+                                                            --namespace ${namespace} \
+                                                            --set aws.enabled=false \
+                                                            --set wso2.apim.configurations.adminUsername="admin" \
+                                                            --set wso2.apim.configurations.adminPassword="admin" \
+                                                            --set wso2.apim.configurations.security.keystores.primary.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.primary.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.tls.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.tls.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.internal.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.internal.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.truststore.password="wso2carbon" \
+                                                            --set wso2.deployment.resources.requests.cpu="1000m" \
+                                                            --set wso2.apim.configurations.userStore.properties.ReadGroups=true \
+                                                            --set kubernetes.ingress.controlPlane.hostname="${portalHost}" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].name="Default" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].type="hybrid" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].gatewayType="Regular" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].provider="wso2" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].displayInApiConsole=true \
+                                                            --set wso2.apim.configurations.gateway.environments[0].description="This is a hybrid gateway that handles both production and sandbox token traffic." \
+                                                            --set wso2.apim.configurations.gateway.environments[0].showAsTokenEndpointUrl=true \
+                                                            --set wso2.apim.configurations.gateway.environments[0].serviceName="apim-universal-gw-wso2am-universal-gw-service" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].servicePort=9443 \
+                                                            --set wso2.apim.configurations.gateway.environments[0].wsHostname="${wsHost}" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].httpHostname="${gwHost}" \
+                                                            --set wso2.apim.configurations.gateway.environments[0].websubHostname="${websubHost}" \
+                                                            --set wso2.apim.configurations.devportal.enableApplicationSharing=true \
+                                                            --set wso2.apim.configurations.devportal.applicationSharingType="default" \
+                                                            --set wso2.apim.configurations.oauth_config.oauth2JWKSUrl="https://apim-acp-wso2am-acp-service:9443/oauth2/jwks" \
+                                                            --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
+                                                            --set wso2.deployment.image.repository="${project}-wso2am-acp:${acpImageTag}" \
+                                                            --set wso2.deployment.image.digest="${wso2amAcpImageDigest}" \
+                                                            --set wso2.deployment.image.imagePullSecrets.enabled=true \
+                                                            --set wso2.deployment.image.imagePullSecrets.username="${dockerRegistryUsernameSafe}" \
+                                                            --set wso2.deployment.image.imagePullSecrets.password="${dockerRegistryPasswordSafe}" \
+                                                            --set wso2.apim.configurations.databases.type="${dbEngineList[dbEngineNameSafe].dbType}" \
+                                                            --set wso2.apim.configurations.databases.jdbc.driver="${dbEngineList[dbEngineNameSafe].dbDriver}" \
+                                                            --set wso2.apim.configurations.databases.apim_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/${apimDbName}?useSSL=false" \
+                                                            --set wso2.apim.configurations.databases.apim_db.username="${dbUser}" \
+                                                            --set wso2.apim.configurations.databases.apim_db.password="${dbPassword}" \
+                                                            --set wso2.apim.configurations.databases.shared_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/${sharedDbName}?useSSL=false" \
+                                                            --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
+                                                            --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}"
+                                                        
+                                                        # Wait for the deployment to be ready
+                                                        kubectl wait --for=condition=available --timeout=400s deployment/apim-acp-wso2am-acp-deployment-1 -n ${namespace}
+
+                                                        # Deploy wso2am-tm (variant: ${dpSafe.tmVariant})
+                                                        echo "Deploying WSO2 API Manager - Traffic Manager [${dpSafe.tmVariant}] in ${namespace} namespace..."
+                                                        helm install apim-tm ${helmChartPath}/distributed/traffic-manager \
+                                                            --namespace ${namespace} \
+                                                            --set aws.enabled=false \
+                                                            --set wso2.apim.configurations.adminUsername="admin" \
+                                                            --set wso2.apim.configurations.adminPassword="admin" \
+                                                            --set wso2.apim.configurations.security.keystores.primary.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.primary.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.tls.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.tls.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.internal.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.internal.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.truststore.password="wso2carbon" \
+                                                            --set wso2.deployment.resources.requests.cpu="1000m" \
+                                                            --set wso2.apim.configurations.km.serviceUrl="apim-acp-wso2am-acp-service" \
+                                                            --set wso2.apim.configurations.eventhub.enabled=true \
+                                                            --set wso2.apim.configurations.eventhub.serviceUrl="apim-acp-wso2am-acp-service" \
+                                                            --set wso2.apim.configurations.eventhub.urls="{apim-acp-wso2am-acp-1-service,apim-acp-wso2am-acp-2-service}" \
+                                                            --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
+                                                            --set wso2.deployment.image.repository="${project}-wso2am-tm:${tmImageTag}" \
+                                                            --set wso2.deployment.image.digest=${wso2amTmImageDigest} \
+                                                            --set wso2.deployment.image.imagePullSecrets.enabled=true \
+                                                            --set wso2.deployment.image.imagePullSecrets.username="${dockerRegistryUsernameSafe}" \
+                                                            --set wso2.deployment.image.imagePullSecrets.password="${dockerRegistryPasswordSafe}" \
+                                                            --set wso2.apim.configurations.databases.type="${dbEngineList[dbEngineNameSafe].dbType}" \
+                                                            --set wso2.apim.configurations.databases.jdbc.driver="${dbEngineList[dbEngineNameSafe].dbDriver}" \
+                                                            --set wso2.apim.configurations.databases.apim_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/${apimDbName}?useSSL=false" \
+                                                            --set wso2.apim.configurations.databases.apim_db.username="${dbUser}" \
+                                                            --set wso2.apim.configurations.databases.apim_db.password="${dbPassword}" \
+                                                            --set wso2.apim.configurations.databases.shared_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/${sharedDbName}?useSSL=false" \
+                                                            --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
+                                                            --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}"
+
+                                                        # Wait for the deployment to be ready
+                                                        kubectl wait --for=condition=available --timeout=400s deployment/apim-tm-wso2am-tm-deployment-1 -n ${namespace}
+
+                                                        # Deploy wso2am-gw (variant: ${dpSafe.gwVariant})
+                                                        echo "Deploying WSO2 API Manager - Gateway [${dpSafe.gwVariant}] in ${namespace} namespace..."
+                                                        helm install apim-universal-gw ${helmChartPath}/distributed/gateway \
+                                                            --namespace ${namespace} \
+                                                            --set aws.enabled=false \
+                                                            --set wso2.apim.configurations.adminUsername="admin" \
+                                                            --set wso2.apim.configurations.adminPassword="admin" \
+                                                            --set wso2.apim.configurations.security.keystores.primary.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.primary.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.tls.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.tls.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.internal.password="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.keystores.internal.keyPassword="wso2carbon" \
+                                                            --set wso2.apim.configurations.security.truststore.password="wso2carbon" \
+                                                            --set wso2.deployment.resources.requests.cpu="1000m" \
+                                                            --set kubernetes.ingress.gateway.hostname="${gwHost}" \
+                                                            --set kubernetes.ingress.websocket.hostname="${wsHost}" \
+                                                            --set kubernetes.ingress.websub.hostname="${websubHost}" \
+                                                            --set wso2.apim.configurations.km.serviceUrl="apim-acp-wso2am-acp-service" \
+                                                            --set wso2.apim.configurations.throttling.serviceUrl="apim-tm-wso2am-tm-service" \
+                                                            --set wso2.apim.configurations.throttling.urls="{apim-tm-wso2am-tm-1-service,apim-tm-wso2am-tm-2-service}" \
+                                                            --set wso2.apim.configurations.eventhub.enabled=true \
+                                                            --set wso2.apim.configurations.eventhub.serviceUrl="apim-acp-wso2am-acp-service" \
+                                                            --set wso2.apim.configurations.eventhub.urls="{apim-acp-wso2am-acp-1-service,apim-acp-wso2am-acp-2-service}" \
+                                                            --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
+                                                            --set wso2.deployment.image.repository="${project}-wso2am-universal-gw:${gwImageTag}" \
+                                                            --set wso2.deployment.image.digest=${wso2amGwImageDigest} \
+                                                            --set wso2.deployment.image.imagePullSecrets.enabled=true \
+                                                            --set wso2.deployment.image.imagePullSecrets.username="${dockerRegistryUsernameSafe}" \
+                                                            --set wso2.deployment.image.imagePullSecrets.password="${dockerRegistryPasswordSafe}" \
+                                                            --set wso2.apim.configurations.databases.type="${dbEngineList[dbEngineNameSafe].dbType}" \
+                                                            --set wso2.apim.configurations.databases.jdbc.driver="${dbEngineList[dbEngineNameSafe].dbDriver}" \
+                                                            --set wso2.apim.configurations.databases.shared_db.url="jdbc:${dbEngineList[dbEngineNameSafe].dbType}://${endpoint}:${dbPort}/${sharedDbName}?useSSL=false" \
+                                                            --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
+                                                            --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}" \
+                                                            --set wso2.deployment.replicas=2 \
+                                                            --set wso2.deployment.minReplicas=2
+                                                        
+                                                        # Wait for the deployment to be ready
+                                                        kubectl wait --for=condition=ready --timeout=300s pod -l deployment=apim-universal-gw-wso2am-universal-gw -n ${namespace}
+                                                    """
                                                 }
-                                                sh "ls -la"
                                             }
+                                        } catch (Exception e) {
+                                            println "Deployment failed for ${stageId}: ${e}"
+                                            error "Deployment failed for ${stageId}. Please check the logs for more details."
                                         }
-                                    } catch (Exception e) {
-                                        println "Test execution failed for ${patternDirSafe}-${dbEngineNameSafe}: ${e}"
-                                        error "Test execution failed for ${patternDirSafe}-${dbEngineNameSafe}. Please check the logs for more details."
+                                    }
+
+                                    stage("Test ${stageId}") {
+                                        if (skipTests) {
+                                            echo "Skipping tests for ${stageId} as skipTests is set to true."
+                                            return
+                                        }
+                                        try {
+                                            withCredentials([
+                                                [
+                                                    $class: 'AmazonWebServicesCredentialsBinding',
+                                                    credentialsId: awsCred,
+                                                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                                ]
+                                            ]) {
+                                                def namespace = (peerTestPatterns.size() > 1) ? "${patternSafe.id}-${dbEngineNameSafe}-${dpName}" : "${patternSafe.id}-${dbEngineNameSafe}"
+                                                def portalHost = (peerTestPatterns.size() > 1) ? "am-${dbEngineNameSafe}-${dpName}.wso2.com" : "am-${dbEngineNameSafe}.wso2.com"
+                                                def gwHost     = (peerTestPatterns.size() > 1) ? "gw-${dbEngineNameSafe}-${dpName}.wso2.com" : "gw-${dbEngineNameSafe}.wso2.com"
+
+                                                dir("${apimIntgDirectory}") {
+                                                    sh """
+                                                        # Change context
+                                                        kubectl config use-context ${patternDirSafe}
+                                                    """
+
+                                                    echo "Waiting for DCR endpoint to be ready for ${stageId}..."
+                                                    sh """#!/bin/bash
+                                                        # Retry loop: Wait up to 5 minutes (30 * 10s) for DCR to return a valid HTTP status
+                                                        for i in \$(seq 1 30); do
+                                                            STATUS=\$(curl -s -o /dev/null -w "%{http_code}" -k -H "Host: ${portalHost}" https://${patternSafe.hostName}/client-registration/v0.17/register)
+                                                            echo "Readiness Check \$i: DCR endpoint returned HTTP \$STATUS"
+                                                            if [[ "\$STATUS" =~ ^[234] ]]; then
+                                                                echo "DCR endpoint is ready (HTTP \$STATUS)! Proceeding..."
+                                                                break
+                                                            fi
+                                                            echo "DCR endpoint not ready yet. Waiting 10s..."
+                                                            sleep 10
+                                                        done
+                                                    """
+
+                                                    sh """
+                                                        ./main.sh --HOSTNAME="${patternSafe.hostName}" \
+                                                            --PORTAL_HOST="${portalHost}" \
+                                                            --GATEWAY_HOST="${gwHost}" \
+                                                            --kubernetes_namespace="${namespace}"
+                                                    """
+                                                }
+
+                                                dir("${logsDirectory}") {
+                                                    def podNames = sh(
+                                                        script: "kubectl get pods -l product=apim -n=${namespace} -o custom-columns=:metadata.name",
+                                                        returnStdout: true
+                                                    ).trim().split('\n')
+                                                    println "APIM pods in namespace ${namespace}: ${podNames}"
+                                                    for (def podName : podNames) {
+                                                        if (podName?.trim()) {
+                                                            // Log filename includes peer test pattern name for traceability
+                                                            def logFile = "${dpName}-${dbEngineNameSafe}-${podName}.log"
+                                                            sh """
+                                                                kubectl logs ${podName} -n=${namespace} > ${logFile} || echo "Failed to get logs for pod ${podName}"
+                                                            """
+                                                        }
+                                                    }
+                                                    sh "ls -la"
+                                                }
+                                            }
+                                        } catch (Exception e) {
+                                            println "Test execution failed for ${stageId}: ${e}"
+                                            error "Test execution failed for ${stageId}. Please check the logs for more details."
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                     
-                    // Run all stages in parallel
+                    // Run all deployment patterns in parallel
                     parallel parallelDeployments
                 }
             }


### PR DESCRIPTION
**Goals**

* Enable parallel execution of 4 distinct deployment patterns (`all-staging`, `acp-staging`, `tm-staging`, `gw-staging`) to verify update compatibility.
* Ensure zero resource collision between parallel deployments by isolating namespaces and databases.

**Approach**

1. **New Parameter:** Added `skipPeerTest` (default `false`). If `false`, the pipeline runs 4 predefined patterns. If `true`, it runs the legacy single `custom` pattern.
2. **Infrastructure Scaling:** Updated `createDeploymentPatterns()` to calculate `eksDesiredSize` dynamically: `nodesPerNamespace (5) * dbEngines * patternCount`.
3. **Database Isolation:** Modified `executeDBScripts()` to accept a `dbSuffix`, creating unique DBs (e.g., `shared_db_all_staging`) for each test pattern.
4. **Docker Builds:** Logic updated to build 6 images in Peer Test mode (3 apps × 2 variants: `latest` & `ga`) versus 3 images in Custom mode.
5. **Deployment Logic:**
* Implemented triple-nested loops (OS × DB × Pattern) to handle parallel deployments.
* Configured pattern-specific Kubernetes namespaces (`{id}-{db}-{dpName}`) and hostnames (`am-{db}-{dpName}.wso2.com`).
* Pre-downloaded APIM packs to prevent race conditions during parallel execution.
6. **Readiness Probe:** Replaced `sleep 60` with a `curl`-based loop that polls the DCR endpoint (`/client-registration/v0.17/register`) every 10 seconds. Explicitly uses `#!/bin/bash` to ensure syntax compatibility.
