### PR TITLE
fix(pipeline): Ensure reliable log collection and improve parallel test execution stability

### DIFF
--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -1248,14 +1248,7 @@ pipeline {
                                             println "Test execution failed for ${stageId}: ${e}"
                                             error "Test execution failed for ${stageId}. Please check the logs for more details."
                                         } finally {
-                                            withCredentials([[
-                                                $class: 'AmazonWebServicesCredentialsBinding',
-                                                credentialsId: awsCred,
-                                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                            ]]) {
-                                                collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-test")
-                                            }
+                                            collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-test")
                                         }
                                     }
                                 }

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -1169,14 +1169,7 @@ pipeline {
                                             }
                                         } catch (Exception e) {
                                             println "Deployment failed for ${stageId}: ${e}"
-                                            withCredentials([[
-                                                $class: 'AmazonWebServicesCredentialsBinding',
-                                                credentialsId: awsCred,
-                                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-                                            ]]) {
-                                                collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-deploy-failure")
-                                            }
+                                            collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-deploy-failure")
                                             error "Deployment failed for ${stageId}. Please check the logs for more details."
                                         }
                                     }

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -138,6 +138,34 @@ def getDbNames(String dbSuffix) {
     return [sharedDbName, apimDbName]
 }
 
+def validateShellSafeValue(String fieldName, String fieldValue) {
+    if (!fieldValue || !(fieldValue ==~ /^[A-Za-z0-9][A-Za-z0-9._-]*$/)) {
+        error "Invalid value for ${fieldName}: '${fieldValue}'. Allowed characters: letters, digits, dot, dash, underscore."
+    }
+}
+
+def validatePipelineInputs(String project, String product, String productVersion, String productDeploymentRegion,
+                           String[] osList, String[] databaseList) {
+    validateShellSafeValue("project", project)
+    validateShellSafeValue("product", product)
+    validateShellSafeValue("productVersion", productVersion)
+    validateShellSafeValue("productDeploymentRegion", productDeploymentRegion)
+
+    if (!osList || osList.length == 0) {
+        error "osList cannot be empty."
+    }
+    for (String os : osList) {
+        validateShellSafeValue("osList entry", os)
+    }
+
+    if (!databaseList || databaseList.length == 0) {
+        error "databaseList cannot be empty."
+    }
+    for (String db : databaseList) {
+        validateShellSafeValue("databaseList entry", db)
+    }
+}
+
 @NonCPS
 def resolvePeerTestPatterns(Boolean skipPeerTest) {
     if (!skipPeerTest) {
@@ -506,49 +534,65 @@ def installDBClients() {
 }
 
 def collectApimLogs(String kubeContext, String namespace, String outputDir, String logPrefix) {
+    def kubeContextQuoted = shellQuote(kubeContext)
+    def namespaceQuoted = shellQuote(namespace)
+    def outputDirQuoted = shellQuote(outputDir)
+    def logPrefixQuoted = shellQuote(logPrefix)
+
     try {
         sh """#!/bin/bash
             set +e
-            mkdir -p "${outputDir}"
+            kube_context=${kubeContextQuoted}
+            namespace=${namespaceQuoted}
+            output_dir=${outputDirQuoted}
+            log_prefix=${logPrefixQuoted}
+            mkdir -p "\${output_dir}"
 
-            if ! kubectl config get-contexts ${kubeContext} >/dev/null 2>&1; then
-                echo "Kubernetes context ${kubeContext} not found. Skipping APIM log collection." > "${outputDir}/${logPrefix}-log-collection.txt"
+            if ! kubectl config get-contexts "\${kube_context}" >/dev/null 2>&1; then
+                echo "Kubernetes context \${kube_context} not found. Skipping APIM log collection." > "\${output_dir}/\${log_prefix}-log-collection.txt"
                 exit 0
             fi
 
-            ns_check_output="\$(kubectl --context=${kubeContext} get namespace ${namespace} 2>&1)"
+            ns_check_output="\$(kubectl --context="\${kube_context}" get namespace "\${namespace}" 2>&1)"
             ns_check_exit=\$?
             if [[ \$ns_check_exit -ne 0 ]]; then
                 if [[ "\$ns_check_output" == *"(NotFound)"* || "\$ns_check_output" == *"not found"* ]]; then
-                    echo "Namespace ${namespace} not found. Skipping APIM log collection." > "${outputDir}/${logPrefix}-log-collection.txt"
+                    echo "Namespace \${namespace} not found. Skipping APIM log collection." > "\${output_dir}/\${log_prefix}-log-collection.txt"
                 else
                     {
-                        echo "Failed to access namespace ${namespace}. Skipping APIM log collection."
+                        echo "Failed to access namespace \${namespace}. Skipping APIM log collection."
                         echo "\$ns_check_output"
-                    } > "${outputDir}/${logPrefix}-log-collection.txt"
+                    } > "\${output_dir}/\${log_prefix}-log-collection.txt"
                 fi
                 exit 0
             fi
 
-            kubectl --context=${kubeContext} get pods -n ${namespace} -o wide > "${outputDir}/${logPrefix}-pods-wide.txt" || true
-            kubectl --context=${kubeContext} get events -n ${namespace} --sort-by=.metadata.creationTimestamp > "${outputDir}/${logPrefix}-events.txt" || true
+            kubectl --context="\${kube_context}" get pods -n "\${namespace}" -o wide > "\${output_dir}/\${log_prefix}-pods-wide.txt" || true
+            kubectl --context="\${kube_context}" get events -n "\${namespace}" --sort-by=.metadata.creationTimestamp > "\${output_dir}/\${log_prefix}-events.txt" || true
 
-            mapfile -t pods < <(kubectl --context=${kubeContext} get pods -n ${namespace} -l product=apim -o custom-columns=:metadata.name --no-headers 2>/dev/null || true)
+            mapfile -t pods < <(kubectl --context="\${kube_context}" get pods -n "\${namespace}" -l product=apim -o custom-columns=:metadata.name --no-headers 2>/dev/null || true)
             if [[ \${#pods[@]} -eq 0 ]]; then
-                echo "No APIM pods found in namespace ${namespace}." > "${outputDir}/${logPrefix}-log-collection.txt"
+                echo "No APIM pods found in namespace \${namespace}." > "\${output_dir}/\${log_prefix}-log-collection.txt"
                 exit 0
             fi
 
             for pod in "\${pods[@]}"; do
                 [[ -z "\${pod}" ]] && continue
-                kubectl --context=${kubeContext} describe pod "\${pod}" -n ${namespace} > "${outputDir}/${logPrefix}-\${pod}.describe.txt" || true
-                kubectl --context=${kubeContext} logs "\${pod}" -n ${namespace} > "${outputDir}/${logPrefix}-\${pod}.log" || true
-                kubectl --context=${kubeContext} logs "\${pod}" -n ${namespace} --previous > "${outputDir}/${logPrefix}-\${pod}.previous.log" || true
+                kubectl --context="\${kube_context}" describe pod "\${pod}" -n "\${namespace}" > "\${output_dir}/\${log_prefix}-\${pod}.describe.txt" || true
+                kubectl --context="\${kube_context}" logs "\${pod}" -n "\${namespace}" > "\${output_dir}/\${log_prefix}-\${pod}.log" || true
+                kubectl --context="\${kube_context}" logs "\${pod}" -n "\${namespace}" --previous > "\${output_dir}/\${log_prefix}-\${pod}.previous.log" || true
             done
         """
     } catch (Exception e) {
         println "Failed to collect APIM logs for namespace ${namespace}: ${e.message}"
     }
+}
+
+def shellQuote(String value) {
+    if (value == null) {
+        return "''"
+    }
+    return "'${value.replace(\"'\", \"'\\\"'\\\"'\")}'"
 }
 
 pipeline {
@@ -575,6 +619,7 @@ pipeline {
         stage('Preparation') {
             steps {
                 script {
+                    validatePipelineInputs(project, product, productVersion, productDeploymentRegion, osList, databaseList)
                     peerTestPatterns = resolvePeerTestPatterns(skipPeerTest)
 
                     println "OS List: ${osList}"

--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -511,8 +511,22 @@ def collectApimLogs(String kubeContext, String namespace, String outputDir, Stri
             set +e
             mkdir -p "${outputDir}"
 
-            if ! kubectl --context=${kubeContext} get namespace ${namespace} >/dev/null 2>&1; then
-                echo "Namespace ${namespace} not found. Skipping APIM log collection." > "${outputDir}/${logPrefix}-log-collection.txt"
+            if ! kubectl config get-contexts ${kubeContext} >/dev/null 2>&1; then
+                echo "Kubernetes context ${kubeContext} not found. Skipping APIM log collection." > "${outputDir}/${logPrefix}-log-collection.txt"
+                exit 0
+            fi
+
+            ns_check_output="\$(kubectl --context=${kubeContext} get namespace ${namespace} 2>&1)"
+            ns_check_exit=\$?
+            if [[ \$ns_check_exit -ne 0 ]]; then
+                if [[ "\$ns_check_output" == *"(NotFound)"* || "\$ns_check_output" == *"not found"* ]]; then
+                    echo "Namespace ${namespace} not found. Skipping APIM log collection." > "${outputDir}/${logPrefix}-log-collection.txt"
+                else
+                    {
+                        echo "Failed to access namespace ${namespace}. Skipping APIM log collection."
+                        echo "\$ns_check_output"
+                    } > "${outputDir}/${logPrefix}-log-collection.txt"
+                fi
                 exit 0
             fi
 
@@ -1110,7 +1124,14 @@ pipeline {
                                             }
                                         } catch (Exception e) {
                                             println "Deployment failed for ${stageId}: ${e}"
-                                            collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-deploy-failure")
+                                            withCredentials([[
+                                                $class: 'AmazonWebServicesCredentialsBinding',
+                                                credentialsId: awsCred,
+                                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                            ]]) {
+                                                collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-deploy-failure")
+                                            }
                                             error "Deployment failed for ${stageId}. Please check the logs for more details."
                                         }
                                     }
@@ -1182,7 +1203,14 @@ pipeline {
                                             println "Test execution failed for ${stageId}: ${e}"
                                             error "Test execution failed for ${stageId}. Please check the logs for more details."
                                         } finally {
-                                            collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-test")
+                                            withCredentials([[
+                                                $class: 'AmazonWebServicesCredentialsBinding',
+                                                credentialsId: awsCred,
+                                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                                            ]]) {
+                                                collectApimLogs(patternDirSafe, namespace, branchLogsDir, "${branchLogPrefix}-test")
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
**Overview**
This PR addresses an issue where Kubernetes pod logs were missing for failed test runs (due to try-catch bypasses and premature namespace deletion). It also introduces several stability improvements for parallel test execution.

**Key Changes**

Guaranteed Log Collection: Moved the log collection logic into a finally block within the Test stage. This ensures logs are always captured regardless of Newman test failures, and crucially, before the global post block destroys the EKS namespaces.
Advanced Diagnostics: Added a dedicated collectApimLogs helper method that securely extracts pod logs, --previous crash logs, pod describe outputs, and Kubernetes events for easier debugging.
Parallel Execution Isolation: The pipeline now creates isolated test directories (testDir) for each parallel branch. This prevents temporary file collisions when multiple Newman instances run simultaneously on the same Jenkins agent.
Pod Stability Probe: Introduced waitForApimPodStability to ensure APIM pods are not just "running" but have stopped restarting (stable restart counts) before traffic is routed to them, reducing flaky test initializations.