### PR TITLE
Fix shell quoting in shellQuote function to handle single quotes corr…

### DIFF
--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -592,7 +592,7 @@ def shellQuote(String value) {
     if (value == null) {
         return "''"
     }
-    return "'${value.replace(\"'\", \"'\\\"'\\\"'\")}'"
+    return "'" + value.replace("'", "'\"'\"'") + "'"
 }
 
 pipeline {


### PR DESCRIPTION
Updated the collectApimLogs shell block to use native Bash variables instead of relying on complex Groovy string interpolation, resolving the unexpected char: '\' build failure.