### PR TITLE
Add helper scripts and update infra json

### DIFF
--- a/scripts/is/intg/helper-scripts/add_patch_repository.sh
+++ b/scripts/is/intg/helper-scripts/add_patch_repository.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 Inc. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 Inc. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2
+# expressly. You may not alter or remove any copyright or other notice from
+# copies of this content.
+#
+# ------------------------------------------------------------------------
+
+
+POM_FILE="pom.xml"
+# Create a backup of the original POM file
+cp "$POM_FILE" "$POM_FILE.bak"
+echo "Created backup at $POM_FILE.bak"
+
+# Function to fix <n> tags to <name> tags (if they exist)
+fix_name_tags() {
+    # Create a temporary file
+    TEMP_FIX=$(mktemp)
+    
+    # Use perl to replace <n> with <name> tags in repository sections
+    perl -pe 's/<n>(.*?)<\/n>/<name>$1<\/name>/g' "$POM_FILE" > "$TEMP_FIX"
+    
+    # Check if any replacements were actually made
+    if diff -q "$POM_FILE" "$TEMP_FIX" >/dev/null; then
+        # Files are identical, no changes were made
+        rm "$TEMP_FIX"
+        echo "No <n> tags found in the repository. Configuration is correct."
+    else
+        # Files differ, changes were made
+        mv "$TEMP_FIX" "$POM_FILE"
+        echo "Repository name tags fixed."
+    fi
+}
+
+# Define the WSO2 repository directly to avoid any formatting issues
+WSO2_REPO='        <repository>
+            <id>wso2-nexus-u2-update-repo</id>
+            <name>Support Nexus Repository of WSO2</name>
+            <url>https://support-maven.wso2.org/nexus/content/repositories/updates-2.0/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>'
+
+# Check if WSO2 repository already exists
+if grep -q '<url>https://support-maven.wso2.org/nexus/content/repositories/updates-2.0/</url>' "$POM_FILE"; then
+    echo "WSO2 repository URL already exists in pom.xml"
+    
+    # Fix any <n> tags to <name> tags
+    if grep -q '<n>' "$POM_FILE"; then
+        echo "Fixing incorrect name tag format in repository..."
+        fix_name_tags
+    else
+        echo "Repository configuration looks correct. No changes needed."
+    fi
+    
+    exit 0
+fi
+
+# Create a temporary file
+TEMP_FILE=$(mktemp)
+
+# Check if <repositories> section exists
+if grep -q '<repositories>' "$POM_FILE"; then
+    while IFS= read -r line; do
+        echo "$line" >> "$TEMP_FILE"
+        if [[ "$line" == *"<repositories>"* ]]; then
+            echo "$WSO2_REPO" >> "$TEMP_FILE"
+        fi
+    done < "$POM_FILE"
+    echo "WSO2 repository added to existing <repositories> section."
+else
+    ADDED=false
+    while IFS= read -r line; do
+        echo "$line" >> "$TEMP_FILE"
+        if [[ "$line" == *"<scm>"* ]] && [ "$ADDED" = false ]; then
+            echo "    <repositories>" >> "$TEMP_FILE"
+            echo "$WSO2_REPO" >> "$TEMP_FILE"
+            echo "    </repositories>" >> "$TEMP_FILE"
+            ADDED=true
+        elif [[ "$line" == *"</project>"* ]] && [ "$ADDED" = false ]; then
+            # Insert before the closing project tag
+            sed -i '' '$d' "$TEMP_FILE" # Remove the last line which is </project>
+            echo "    <repositories>" >> "$TEMP_FILE"
+            echo "$WSO2_REPO" >> "$TEMP_FILE"
+            echo "    </repositories>" >> "$TEMP_FILE"
+            echo "$line" >> "$TEMP_FILE" # Add back the </project> line
+            ADDED=true
+        fi
+    done < "$POM_FILE"
+    echo "New <repositories> section added with WSO2 repository."
+fi
+
+# Ensure the </project> tag is present
+if ! grep -q '</project>' "$TEMP_FILE"; then
+    echo "</project>" >> "$TEMP_FILE"
+fi
+
+# Replace the original POM file with the modified one
+mv "$TEMP_FILE" "$POM_FILE"
+
+# Fix any <n> tags to <name> tags
+if grep -q '<n>' "$POM_FILE"; then
+    echo "Fixing incorrect name tag format in repository..."
+    fix_name_tags
+fi

--- a/scripts/is/intg/helper-scripts/consolidate_db_is.sh
+++ b/scripts/is/intg/helper-scripts/consolidate_db_is.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 Inc. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 Inc. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2
+# expressly. You may not alter or remove any copyright or other notice from
+# copies of this content.
+#
+# ------------------------------------------------------------------------
+
+echo "Creating DB scripts for WSO2-IS based on DB Engine"
+
+# Define files and databases
+DB_ENGINE='CF_DBMS_NAME'
+SCRIPT_LOCATION='CF_SCRIPT_LOCATION'
+WSO2_PRODUCT_VERSION_SHORT='CF_PRODUCT_VERSION_SHORT'
+
+if [ $DB_ENGINE = "postgres" ]; then
+  # Create database creation script
+  db_create_file="$WSO2_PRODUCT_VERSION_SHORT/is_postgres_db_create.sql"
+  touch "$db_create_file"
+  echo "-- PostgreSQL Database Creation Script" > "$db_create_file"
+  echo "DROP DATABASE IF EXISTS \"WSO2SHARED_DB\";" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS \"WSO2BPS_DB\";" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS \"WSO2IDENTITY_DB\";" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS \"WSO2CONSENT_DB\";" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS \"WSO2METRICS_DB\";" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS \"WSO2AGENTIDENTITY_DB\";" >> "$db_create_file"
+  echo "" >> "$db_create_file"
+  echo "CREATE DATABASE \"WSO2SHARED_DB\" LC_COLLATE = 'C' LC_CTYPE = 'C' TEMPLATE = template0;" >> "$db_create_file"
+  echo "CREATE DATABASE \"WSO2IS_BPS_DB\" LC_COLLATE = 'C' LC_CTYPE = 'C' TEMPLATE = template0;" >> "$db_create_file"
+  echo "CREATE DATABASE \"WSO2IDENTITY_DB\" LC_COLLATE = 'C' LC_CTYPE = 'C' TEMPLATE = template0;" >> "$db_create_file"
+  echo "CREATE DATABASE \"WSO2CONSENT_DB\" LC_COLLATE = 'C' LC_CTYPE = 'C' TEMPLATE = template0;" >> "$db_create_file"
+  echo "CREATE DATABASE \"WSO2_METRICS_DB\" LC_COLLATE = 'C' LC_CTYPE = 'C' TEMPLATE = template0;" >> "$db_create_file"
+  echo "CREATE DATABASE \"WSO2AGENTIDENTITY_DB\" LC_COLLATE = 'C' LC_CTYPE = 'C' TEMPLATE = template0;" >> "$db_create_file"
+  
+  # Create schema scripts for each database (consent is merged into identity)
+  sql_files=("$SCRIPT_LOCATION/postgresql.sql" "$SCRIPT_LOCATION/identity/postgresql.sql" "$SCRIPT_LOCATION/identity/agent/postgresql.sql")
+  output_files=("$WSO2_PRODUCT_VERSION_SHORT/is_postgres_shared.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_postgres_identity.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_postgres_agent_identity.sql")
+
+  for i in "${!output_files[@]}"; do
+    cat "${sql_files[$i]}" > "${output_files[$i]}"
+    echo "" >> "${output_files[$i]}"
+  done
+
+  # Append consent schema into the identity SQL file
+  cat "$SCRIPT_LOCATION/consent/postgresql.sql" >> "$WSO2_PRODUCT_VERSION_SHORT/is_postgres_identity.sql"
+  echo "" >> "$WSO2_PRODUCT_VERSION_SHORT/is_postgres_identity.sql"
+
+elif [ $DB_ENGINE = "mysql" ]; then
+  # Create database creation script
+  db_create_file="$WSO2_PRODUCT_VERSION_SHORT/is_mysql_db_create.sql"
+  touch "$db_create_file"
+  echo "-- MySQL Database Creation Script" > "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2SHARED_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2IDENTITY_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2IS_BPS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2CONSENT_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_METRICS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_CLUSTER_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS IS_ANALYTICS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_CARBON_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_PERSISTENCE_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_STATUS_DASHBOARD_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2AGENTIDENTITY_DB;" >> "$db_create_file"
+  echo "" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2SHARED_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IDENTITY_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IS_BPS_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2CONSENT_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_METRICS_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_CLUSTER_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE IS_ANALYTICS_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_CARBON_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_PERSISTENCE_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_STATUS_DASHBOARD_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2AGENTIDENTITY_DB character set latin1;" >> "$db_create_file"
+  
+  # Create schema scripts for each database (consent is merged into identity)
+  sql_files=("$SCRIPT_LOCATION/mysql.sql" "$SCRIPT_LOCATION/identity/mysql.sql" "$SCRIPT_LOCATION/identity/agent/mysql.sql")
+  output_files=("$WSO2_PRODUCT_VERSION_SHORT/is_mysql_shared.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_mysql_identity.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_mysql_agent_identity.sql")
+
+  for i in "${!output_files[@]}"; do
+    cat "${sql_files[$i]}" > "${output_files[$i]}"
+    echo "" >> "${output_files[$i]}"
+  done
+
+  # Append consent schema into the identity SQL file
+  cat "$SCRIPT_LOCATION/consent/mysql.sql" >> "$WSO2_PRODUCT_VERSION_SHORT/is_mysql_identity.sql"
+  echo "" >> "$WSO2_PRODUCT_VERSION_SHORT/is_mysql_identity.sql"
+
+elif [ $DB_ENGINE = "mariadb" ]; then
+  # Create database creation script
+  db_create_file="$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_db_create.sql"
+  touch "$db_create_file"
+  echo "-- MariaDB Database Creation Script" > "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2SHARED_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2IDENTITY_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2IS_BPS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2CONSENT_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_METRICS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_CLUSTER_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS IS_ANALYTICS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_CARBON_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_PERSISTENCE_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_STATUS_DASHBOARD_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2AGENTIDENTITY_DB;" >> "$db_create_file"
+  echo "" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2SHARED_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IDENTITY_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IS_BPS_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2CONSENT_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_METRICS_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_CLUSTER_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE IS_ANALYTICS_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_CARBON_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_PERSISTENCE_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_STATUS_DASHBOARD_DB character set latin1;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2AGENTIDENTITY_DB character set latin1;" >> "$db_create_file"
+  
+  # Create schema scripts for each database (consent is merged into identity)
+  sql_files=("$SCRIPT_LOCATION/mysql.sql" "$SCRIPT_LOCATION/identity/mysql.sql" "$SCRIPT_LOCATION/identity/agent/mysql.sql")
+  output_files=("$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_shared.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_identity.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_agent_identity.sql")
+
+  for i in "${!output_files[@]}"; do
+    cat "${sql_files[$i]}" > "${output_files[$i]}"
+    echo "" >> "${output_files[$i]}"
+  done
+
+  # Append consent schema into the identity SQL file
+  cat "$SCRIPT_LOCATION/consent/mysql.sql" >> "$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_identity.sql"
+  echo "" >> "$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_identity.sql"
+
+elif [ $DB_ENGINE = "sqlserver-se" ]; then
+  # Create database creation script
+  db_create_file="$WSO2_PRODUCT_VERSION_SHORT/is_mssql_db_create.sql"
+  touch "$db_create_file"
+  echo "-- SQL Server Database Creation Script" > "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2SHARED_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2IS_BPS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2IDENTITY_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2CONSENT_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2_METRICS_DB;" >> "$db_create_file"
+  echo "DROP DATABASE IF EXISTS WSO2AGENTIDENTITY_DB;" >> "$db_create_file"
+  echo "GO" >> "$db_create_file"
+  echo "" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2SHARED_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IS_BPS_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IDENTITY_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2CONSENT_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_METRICS_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2AGENTIDENTITY_DB;" >> "$db_create_file"
+  echo "GO" >> "$db_create_file"
+  echo "" >> "$db_create_file"
+  # Grant the login access to each created database
+  for db in WSO2SHARED_DB WSO2IS_BPS_DB WSO2IDENTITY_DB WSO2CONSENT_DB WSO2_METRICS_DB WSO2AGENTIDENTITY_DB; do
+    echo "USE $db;" >> "$db_create_file"
+    echo "GO" >> "$db_create_file"
+    echo "IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = 'CF_DB_USERNAME')" >> "$db_create_file"
+    echo "BEGIN" >> "$db_create_file"
+    echo "    CREATE USER [CF_DB_USERNAME] FOR LOGIN [CF_DB_USERNAME];" >> "$db_create_file"
+    echo "END" >> "$db_create_file"
+    echo "GO" >> "$db_create_file"
+    echo "ALTER ROLE db_owner ADD MEMBER [CF_DB_USERNAME];" >> "$db_create_file"
+    echo "GO" >> "$db_create_file"
+    echo "" >> "$db_create_file"
+  done
+  
+  # Create schema scripts for each database (consent is merged into identity)
+  sql_files=("$SCRIPT_LOCATION/mssql.sql" "$SCRIPT_LOCATION/identity/mssql.sql" "$SCRIPT_LOCATION/identity/agent/mssql.sql")
+  output_files=("$WSO2_PRODUCT_VERSION_SHORT/is_mssql_shared.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_mssql_identity.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_mssql_agent_identity.sql")
+
+  for i in "${!output_files[@]}"; do
+    # Add USE DATABASE statement for SQL Server (use > to overwrite any existing file)
+    if [ "$i" -eq 0 ]; then
+      echo "USE WSO2SHARED_DB;" > "${output_files[$i]}"
+      echo "GO" >> "${output_files[$i]}"
+    elif [ "$i" -eq 1 ]; then
+      echo "USE WSO2IDENTITY_DB;" > "${output_files[$i]}"
+      echo "GO" >> "${output_files[$i]}"
+    elif [ "$i" -eq 2 ]; then
+      echo "USE WSO2AGENTIDENTITY_DB;" > "${output_files[$i]}"
+      echo "GO" >> "${output_files[$i]}"
+    fi
+    cat "${sql_files[$i]}" >> "${output_files[$i]}"
+    echo "" >> "${output_files[$i]}"
+  done
+
+  # Append consent schema into the identity SQL file (no USE change — stays in WSO2IDENTITY_DB context)
+  cat "$SCRIPT_LOCATION/consent/mssql.sql" >> "$WSO2_PRODUCT_VERSION_SHORT/is_mssql_identity.sql"
+  echo "" >> "$WSO2_PRODUCT_VERSION_SHORT/is_mssql_identity.sql"
+
+elif [[ $DB_ENGINE =~ 'oracle-se' ]]; then
+  # Create schema scripts for each database (consent is merged into identity)
+  sql_files=("$SCRIPT_LOCATION/oracle.sql" "$SCRIPT_LOCATION/identity/oracle.sql" "$SCRIPT_LOCATION/identity/agent/oracle.sql")
+  output_files=("$WSO2_PRODUCT_VERSION_SHORT/is_oracle_common.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_oracle_identity.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_oracle_agent_identity.sql")
+
+  # Loop through files and write content (use > to overwrite any existing file)
+  for i in "${!sql_files[@]}"; do
+    cat "${sql_files[$i]}" > "${output_files[$i]}"
+    echo "" >> "${output_files[$i]}"
+  done
+
+  # Append consent schema into the identity SQL file
+  cat "$SCRIPT_LOCATION/consent/oracle.sql" >> "$WSO2_PRODUCT_VERSION_SHORT/is_oracle_identity.sql"
+  echo "" >> "$WSO2_PRODUCT_VERSION_SHORT/is_oracle_identity.sql"
+
+elif [ $DB_ENGINE = "db2-se" ]; then
+  # Create database creation script
+  db_create_file="$WSO2_PRODUCT_VERSION_SHORT/is_db2_db_create.sql"
+  touch "$db_create_file"
+  echo "-- DB2 Database Creation Script" > "$db_create_file"
+  echo "BEGIN" >> "$db_create_file"
+  echo "    DECLARE CONTINUE HANDLER FOR SQLSTATE '42704' BEGIN END;" >> "$db_create_file"
+  echo "    DROP DATABASE WSO2SHARED_DB;" >> "$db_create_file"
+  echo "    DROP DATABASE WSO2IS_BPS_DB;" >> "$db_create_file"
+  echo "    DROP DATABASE WSO2IDENTITY_DB;" >> "$db_create_file"
+  echo "    DROP DATABASE WSO2CONSENT_DB;" >> "$db_create_file"
+  echo "    DROP DATABASE WSO2_METRICS_DB;" >> "$db_create_file"
+  echo "    DROP DATABASE WSO2AGENTIDENTITY_DB;" >> "$db_create_file"
+  echo "END;" >> "$db_create_file"
+  echo "" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2SHARED_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IS_BPS_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2IDENTITY_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2CONSENT_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2_METRICS_DB;" >> "$db_create_file"
+  echo "CREATE DATABASE WSO2AGENTIDENTITY_DB;" >> "$db_create_file"
+  
+  # Create schema scripts for each database (consent is merged into identity)
+  sql_files=("$SCRIPT_LOCATION/db2.sql" "$SCRIPT_LOCATION/identity/db2.sql" "$SCRIPT_LOCATION/identity/agent/db2.sql")
+  output_files=("$WSO2_PRODUCT_VERSION_SHORT/is_db2_shared.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_db2_identity.sql" "$WSO2_PRODUCT_VERSION_SHORT/is_db2_agent_identity.sql")
+
+  for i in "${!output_files[@]}"; do
+    cat "${sql_files[$i]}" > "${output_files[$i]}"
+    echo "" >> "${output_files[$i]}"
+  done
+
+  # Append consent schema into the identity SQL file
+  cat "$SCRIPT_LOCATION/consent/db2.sql" >> "$WSO2_PRODUCT_VERSION_SHORT/is_db2_identity.sql"
+  echo "" >> "$WSO2_PRODUCT_VERSION_SHORT/is_db2_identity.sql"
+fi
+
+echo "SQL files appended successfully"

--- a/scripts/is/intg/helper-scripts/provision_db_is.sh
+++ b/scripts/is/intg/helper-scripts/provision_db_is.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 Inc. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 Inc. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2
+# expressly. You may not alter or remove any copyright or other notice from
+# copies of this content.
+#
+# ------------------------------------------------------------------------
+
+#Running Database scripts for WSO2-IS
+echo "Running DB scripts for WSO2-IS..."
+
+#Define parameter values for Database Engine and Version
+
+DB_ENGINE='CF_DBMS_NAME'
+DB_ENGINE_VERSION='CF_DBMS_VERSION'
+WSO2_PRODUCT_VERSION='CF_PRODUCT_VERSION'
+USE_CONSENT_DB=false
+
+#Select product version
+if [ $WSO2_PRODUCT_VERSION = "5.2.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is520
+elif [ $WSO2_PRODUCT_VERSION = "5.3.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is530
+elif [ $WSO2_PRODUCT_VERSION = "5.4.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is540
+elif [ $WSO2_PRODUCT_VERSION = "5.4.1" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is541
+elif [ $WSO2_PRODUCT_VERSION = "5.5.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is550
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "5.6.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is560
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "5.7.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is570
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "5.8.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is580
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "5.9.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is590
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "5.10.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is5100
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "5.11.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is5110
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "6.0.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is600
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "6.1.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is610
+    USE_CONSENT_DB=true
+elif [ $WSO2_PRODUCT_VERSION = "7.0.0" ]; then
+    WSO2_PRODUCT_VERSION_SHORT=is700
+    USE_CONSENT_DB=true
+elif [[ $WSO2_PRODUCT_VERSION == *"7.1.0"* ]]; then
+    WSO2_PRODUCT_VERSION_SHORT=is710
+    USE_CONSENT_DB=true
+elif [[ $WSO2_PRODUCT_VERSION == *"7.2.0"* ]]; then
+    WSO2_PRODUCT_VERSION_SHORT=is720
+    USE_CONSENT_DB=true
+elif [[ $WSO2_PRODUCT_VERSION == *"7.2.1"* ]]; then
+    WSO2_PRODUCT_VERSION_SHORT=is721
+    USE_CONSENT_DB=true
+elif [[ $WSO2_PRODUCT_VERSION == *"7.3.0"* ]]; then
+    WSO2_PRODUCT_VERSION_SHORT=is730
+    USE_CONSENT_DB=true
+fi
+
+#Run database scripts for given database engine and product version
+
+if [[ $DB_ENGINE = "postgres" ]]; then
+    # DB Engine : Postgres
+    echo "Postgres DB Engine Selected! Running WSO2-IS $WSO2_PRODUCT_VERSION DB Scripts for Postgres..."
+    export PGPASSWORD=CF_DB_PASSWORD
+    
+    # Step 1: Create databases (connect to default 'postgres' database)
+    echo "Creating databases..."
+    psql -U CF_DB_USERNAME -h CF_DB_HOST -p CF_DB_PORT -d postgres -f /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_postgres_db_create.sql
+    
+    # Step 2: Populate each database with its schema
+    echo "Populating WSO2SHARED_DB schema..."
+    psql -U CF_DB_USERNAME -h CF_DB_HOST -p CF_DB_PORT -d WSO2SHARED_DB -f /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_postgres_shared.sql
+    
+    echo "Populating WSO2IDENTITY_DB schema..."
+    psql -U CF_DB_USERNAME -h CF_DB_HOST -p CF_DB_PORT -d WSO2IDENTITY_DB -f /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_postgres_identity.sql
+    
+    echo "Populating WSO2CONSENT_DB schema..."
+    psql -U CF_DB_USERNAME -h CF_DB_HOST -p CF_DB_PORT -d WSO2CONSENT_DB -f /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_postgres_consent.sql
+    
+    echo "Populating WSO2AGENTIDENTITY_DB schema..."
+    psql -U CF_DB_USERNAME -h CF_DB_HOST -p CF_DB_PORT -d WSO2AGENTIDENTITY_DB -f /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_postgres_agent_identity.sql
+elif [[ $DB_ENGINE = "mysql" ]]; then
+    # DB Engine : MySQL
+    echo "MySQL DB Engine Selected! Running WSO2-IS $WSO2_PRODUCT_VERSION DB Scripts for MySQL..."
+    
+    # Step 1: Create databases
+    echo "Creating databases..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mysql_db_create.sql
+    
+    # Step 2: Populate each database with its schema
+    echo "Populating WSO2SHARED_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2SHARED_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mysql_shared.sql
+    
+    echo "Populating WSO2IDENTITY_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2IDENTITY_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mysql_identity.sql
+    
+    echo "Populating WSO2CONSENT_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2CONSENT_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mysql_consent.sql
+    
+    echo "Populating WSO2AGENTIDENTITY_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2AGENTIDENTITY_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mysql_agent_identity.sql
+elif [[ $DB_ENGINE = "mariadb" ]]; then
+    # DB Engine : mariadb
+    echo "Maria DB Engine Selected! Running WSO2-IS $WSO2_PRODUCT_VERSION DB Scripts for MariaDB..."
+    
+    # Step 1: Create databases
+    echo "Creating databases..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_db_create.sql
+    
+    # Step 2: Populate each database with its schema
+    echo "Populating WSO2SHARED_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2SHARED_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_shared.sql
+    
+    echo "Populating WSO2IDENTITY_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2IDENTITY_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_identity.sql
+    
+    echo "Populating WSO2CONSENT_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2CONSENT_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_consent.sql
+    
+    echo "Populating WSO2AGENTIDENTITY_DB schema..."
+    mysql -u CF_DB_USERNAME -pCF_DB_PASSWORD -h CF_DB_HOST -P CF_DB_PORT WSO2AGENTIDENTITY_DB < /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mariadb_agent_identity.sql
+elif [[ $DB_ENGINE =~ 'oracle-se' ]]; then
+    # DB Engine : Oracle
+    echo "Oracle DB Engine Selected! Running WSO2-IS $WSO2_PRODUCT_VERSION DB Scripts for Oracle..."
+    # All scripts run as CF_DB_USERNAME against the single Oracle database CF_DB_NAME
+    
+    echo "--------------------IDENTITY---------------------"
+    echo exit | sqlplus64 CF_DB_USERNAME/CF_DB_PASSWORD@//CF_DB_HOST:CF_DB_PORT/CF_DB_NAME @/opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_oracle_identity.sql
+    
+    echo "--------------------COMMON---------------------"
+    echo exit | sqlplus64 CF_DB_USERNAME/CF_DB_PASSWORD@//CF_DB_HOST:CF_DB_PORT/CF_DB_NAME @/opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_oracle_common.sql
+    
+    echo "--------------------CONSENT---------------------"
+    if $USE_CONSENT_DB; then
+        echo exit | sqlplus64 CF_DB_USERNAME/CF_DB_PASSWORD@//CF_DB_HOST:CF_DB_PORT/CF_DB_NAME @/opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_oracle_consent.sql
+    fi
+    
+    echo "--------------------AGENT IDENTITY---------------------"
+    echo exit | sqlplus64 CF_DB_USERNAME/CF_DB_PASSWORD@//CF_DB_HOST:CF_DB_PORT/CF_DB_NAME @/opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_oracle_agent_identity.sql
+    
+    echo "--------------------BPS---------------------"
+    if [[ $WSO2_PRODUCT_VERSION != "7.0.0" && $WSO2_PRODUCT_VERSION != "7.1.0-SNAPSHOT" && $WSO2_PRODUCT_VERSION != "7.1.0" && $WSO2_PRODUCT_VERSION != "7.2.0" && $WSO2_PRODUCT_VERSION != *"7.2.1"* && $WSO2_PRODUCT_VERSION != *"7.3.0"* ]]; then
+        echo exit | sqlplus64 CF_DB_USERNAME/CF_DB_PASSWORD@//CF_DB_HOST:CF_DB_PORT/CF_DB_NAME @/opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_oracle_bps.sql
+    fi
+elif [[ $DB_ENGINE =~ 'sqlserver-se' ]]; then
+    # DB Engine : SQLServer
+    echo "SQL Server DB Engine Selected! Running WSO2-IS $WSO2_PRODUCT_VERSION DB Scripts for SQL Server..."
+    
+    # Step 1: Create databases
+    echo "Creating databases..."
+    sqlcmd -S CF_DB_HOST -U CF_DB_USERNAME -P CF_DB_PASSWORD -C -i /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mssql_db_create.sql
+    
+    # Step 2: Populate each database with its schema (USE DATABASE statement included in schema files)
+    echo "Populating WSO2SHARED_DB schema..."
+    sqlcmd -S CF_DB_HOST -U CF_DB_USERNAME -P CF_DB_PASSWORD -C -i /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mssql_shared.sql
+    
+    echo "Populating WSO2IDENTITY_DB schema..."
+    sqlcmd -S CF_DB_HOST -U CF_DB_USERNAME -P CF_DB_PASSWORD -C -i /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mssql_identity.sql
+    
+    echo "Populating WSO2CONSENT_DB schema..."
+    sqlcmd -S CF_DB_HOST -U CF_DB_USERNAME -P CF_DB_PASSWORD -C -i /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mssql_consent.sql
+    
+    echo "Populating WSO2AGENTIDENTITY_DB schema..."
+    sqlcmd -S CF_DB_HOST -U CF_DB_USERNAME -P CF_DB_PASSWORD -C -i /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_mssql_agent_identity.sql
+elif [[ $DB_ENGINE = "db2-se" ]]; then
+    # DB Engine : DB2
+    echo "DB2 DB Engine Selected! Running WSO2-IS $WSO2_PRODUCT_VERSION DB Scripts for DB2..."
+    
+    # Step 1: Create databases
+    echo "Creating databases..."
+    db2cli execsql -execute -dsn CF_DB_NAME -u CF_DB_USERNAME -p CF_DB_PASSWORD -h CF_DB_HOST -p CF_DB_PORT -inputsql /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_db2_db_create.sql -outfile /tmp/db2_create_output.log -statementdelimiter ";" -commentstart "--"
+    
+    # Step 2: Populate each database with its schema
+    echo "Populating WSO2SHARED_DB schema..."
+    db2 connect to WSO2SHARED_DB user CF_DB_USERNAME using CF_DB_PASSWORD
+    db2 -tvf /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_db2_shared.sql
+    db2 connect reset
+    
+    echo "Populating WSO2IDENTITY_DB schema..."
+    db2 connect to WSO2IDENTITY_DB user CF_DB_USERNAME using CF_DB_PASSWORD
+    db2 -tvf /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_db2_identity.sql
+    db2 connect reset
+    
+    echo "Populating WSO2CONSENT_DB schema..."
+    db2 connect to WSO2CONSENT_DB user CF_DB_USERNAME using CF_DB_PASSWORD
+    db2 -tvf /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_db2_consent.sql
+    db2 connect reset
+    
+    echo "Populating WSO2AGENTIDENTITY_DB schema..."
+    db2 connect to WSO2AGENTIDENTITY_DB user CF_DB_USERNAME using CF_DB_PASSWORD
+    db2 -tvf /opt/testgrid/workspace/$WSO2_PRODUCT_VERSION_SHORT/is_db2_agent_identity.sql
+    db2 connect reset
+fi
+
+echo "Database Provision Complete"

--- a/scripts/is/intg/helper-scripts/update_db_configs.sh
+++ b/scripts/is/intg/helper-scripts/update_db_configs.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 Inc. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 Inc. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2
+# expressly. You may not alter or remove any copyright or other notice from
+# copies of this content.
+#
+# ------------------------------------------------------------------------
+
+# Script to update WSO2 deployment.toml with database configuration from infra.json
+# Usage: ./update_db_config.sh <db_type>
+# Example: ./update_db_config.sh mysql
+
+# Check if a database type was provided
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <db_type>"
+    echo "Available database types: $(jq -r '.jdbc[].name' infra.json | tr '\n' ', ' | sed 's/,$//')"
+    exit 1
+fi
+
+DB_TYPE_INPUT=$1
+WSO2_PRODUCT_VERSION=$2
+DEPLOYMENT_TOML="$WSO2_PRODUCT_VERSION/repository/conf/deployment.toml"
+INFRA_JSON="infra.json"
+NEW_TOML="${DEPLOYMENT_TOML}.new"
+BACKUP_TOML="${DEPLOYMENT_TOML}.bak"
+
+# Check if files exist
+if [ ! -f "$INFRA_JSON" ]; then
+    echo "Error: $INFRA_JSON not found"
+    exit 1
+fi
+
+if [ ! -f "$DEPLOYMENT_TOML" ]; then
+    echo "Error: $DEPLOYMENT_TOML not found"
+    exit 1
+fi
+
+DB_TYPE=$DB_TYPE_INPUT
+
+# Check if the database type exists in infra.json
+
+DB_EXISTS=$(jq -r --arg db "$DB_TYPE" '.jdbc[] | select(.name == $db) | .name' "$INFRA_JSON")
+if [ -z "$DB_EXISTS" ]; then
+    echo "Error: Database type '$DB_TYPE' (mapped from '$DB_TYPE_INPUT') not found in $INFRA_JSON"
+    echo "Available database types: $(jq -r '.jdbc[].name' "$INFRA_JSON" | tr '\n' ', ' | sed 's/,$//')"
+    exit 1
+fi
+
+echo "Updating $DEPLOYMENT_TOML with $DB_TYPE database configuration..."
+
+# Create a backup
+cp "$DEPLOYMENT_TOML" "$BACKUP_TOML"
+
+# Extract AgentIdentity URL to check if it is configured in infra.json
+AGENTIDENTITY_URL=$(jq -r --arg db "$DB_TYPE" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2AGENTIDENTITY_DB") | .url' "$INFRA_JSON")
+
+# Create new content
+{
+  # Read the file until we find identity_db section
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^\[database.identity_db\] ]]; then
+      # Write the identity_db section
+      echo "[database.identity_db]"
+      echo "type = \"\$env{IDENTITY_DATABASE_TYPE}\""
+      echo "url = \"\$env{IDENTITY_DATABASE_URL}\""
+      echo "username = \"\$env{IDENTITY_DATABASE_USERNAME}\""
+      echo "password = \"\$env{IDENTITY_DATABASE_PASSWORD}\""
+      echo "driver = \"\$env{IDENTITY_DATABASE_DRIVER}\""
+      echo "validationQuery = \"\$env{IDENTITY_DATABASE_VALIDATION_QUERY}\""
+      echo ""
+      
+      # Skip the original section
+      while IFS= read -r section_line; do
+        if [[ "$section_line" =~ ^\[ ]]; then
+          # We reached a new section, process it
+          if [[ "$section_line" =~ ^\[database.shared_db\] ]]; then
+            # Write shared_db section
+            echo "[database.shared_db]"
+            echo "type = \"\$env{SHARED_DATABASE_TYPE}\""
+            echo "url = \"\$env{SHARED_DATABASE_URL}\""
+            echo "username = \"\$env{SHARED_DATABASE_USERNAME}\""
+            echo "password = \"\$env{SHARED_DATABASE_PASSWORD}\""
+            echo "driver = \"\$env{SHARED_DATABASE_DRIVER}\""
+            echo "validationQuery = \"\$env{SHARED_DATABASE_VALIDATION_QUERY}\""
+            echo ""
+            
+            # Skip the original shared_db section
+            while IFS= read -r shared_section_line; do
+              if [[ "$shared_section_line" =~ ^\[ ]]; then
+                # We reached the next section after shared_db
+                if [[ "$shared_section_line" =~ ^\[datasource.AgentIdentity\] ]]; then
+                  # Write AgentIdentity datasource section if AGENTIDENTITY_DB exists
+                  if [ -n "$AGENTIDENTITY_URL" ] && [ "$AGENTIDENTITY_URL" != "null" ]; then
+                    echo "[datasource.AgentIdentity]"
+                    echo "id = \"AgentIdentity\""
+                    echo "type = \"\$env{AGENTIDENTITY_DATABASE_TYPE}\""
+                    echo "url = \"\$env{AGENTIDENTITY_DATABASE_URL}\""
+                    echo "username = \"\$env{AGENTIDENTITY_DATABASE_USERNAME}\""
+                    echo "password = \"\$env{AGENTIDENTITY_DATABASE_PASSWORD}\""
+                    echo "driver = \"\$env{AGENTIDENTITY_DATABASE_DRIVER}\""
+                    echo "validationQuery = \"\$env{AGENTIDENTITY_DATABASE_VALIDATION_QUERY}\""
+                    echo ""
+                    
+                    # Skip the original AgentIdentity section
+                    while IFS= read -r agent_section_line; do
+                      if [[ "$agent_section_line" =~ ^\[ ]]; then
+                        # We reached the next section after AgentIdentity
+                        echo "$agent_section_line"
+                        break
+                      fi
+                    done
+                  else
+                    # If no AGENTIDENTITY_DB in infra.json, keep the original section
+                    echo "$shared_section_line"
+                  fi
+                else
+                  echo "$shared_section_line"
+                fi
+                break
+              fi
+            done
+          else
+            # This is not the shared_db section, just echo it
+            echo "$section_line"
+          fi
+          break
+        fi
+      done
+    else
+      echo "$line"
+    fi
+  done
+} < "$BACKUP_TOML" > "$NEW_TOML"
+
+# Replace original file with our new file
+mv "$NEW_TOML" "$DEPLOYMENT_TOML"
+
+echo "Database configuration updated successfully for '$DB_TYPE_INPUT' (mapped to '$DB_TYPE_DISPLAY')"
+
+# Show the updated sections
+echo -e "\nUpdated database configuration in $DEPLOYMENT_TOML:"
+grep -A 6 "^\[database\." "$DEPLOYMENT_TOML"

--- a/scripts/is/intg/infra.json
+++ b/scripts/is/intg/infra.json
@@ -34,6 +34,10 @@
 			"file_name": "OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13"
 		},
 		{
+			"name": "ADOPT_OPEN_JDK25",
+			"file_name": "openjdk-25.0.2_linux-x64_bin"
+		},
+		{
 			"name": "ADOPT_OPEN_JDK11_ARM",
 			"file_name": "OpenJDK11U-jdk_aarch64_linux_11.0.7_10"
 		},
@@ -44,6 +48,10 @@
 		{
 			"name": "ADOPT_OPEN_JDK21_ARM",
 			"file_name": "OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.2_13"
+		},
+		{
+			"name": "ADOPT_OPEN_JDK25_ARM",
+			"file_name": "openjdk-25.0.2_linux-aarch64_bin"
 		}
 	],
     "jdbc": 
@@ -64,25 +72,37 @@
 					"url": "jdbc:db2://DB_HOST:50000/WSO2SHARED_DB:retrieveMessagesFromServerOnGetMessage=true;",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
+				},
+                {
+					"name": "WSO2AGENTIDENTITY_DB",
+					"url": "jdbc:db2://DB_HOST:50000/WSO2AGENTIDENTITY_DB:retrieveMessagesFromServerOnGetMessage=true;",
+					"username": "DB_USERNAME",
+					"password": "DB_PASSWORD"
 				}
 			],
 			"validation_query": "SELECT 1 FROM SYSIBM.SYSDUMMY1"
 		},
         {
 			"name": "mysql",
-			"file_name": "mysql-connector-java-8.0.28",
-			"driver": "com.mysql.jdbc.Driver",
+			"file_name": "mysql-connector-j-9.6.0",
+			"driver": "com.mysql.cj.jdbc.Driver",
             "database": 
             [
                 {
 					"name": "WSO2IDENTITY_DB",
-                    "url": "jdbc:mysql://DB_HOST:3306/WSO2IDENTITY_DB?autoReconnect=true&amp;useSSL=false",
+					"url": "jdbc:mysql://DB_HOST:3306/WSO2IDENTITY_DB?autoReconnect=true&amp;amp;useSSL=false",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				},
 				{
 					"name": "WSO2SHARED_DB",
-					"url": "jdbc:mysql://DB_HOST:3306/WSO2SHARED_DB?autoReconnect=true&amp;useSSL=false",
+					"url": "jdbc:mysql://DB_HOST:3306/WSO2SHARED_DB?autoReconnect=true&amp;amp;useSSL=false",
+					"username": "DB_USERNAME",
+					"password": "DB_PASSWORD"
+				},
+				{
+					"name": "WSO2AGENTIDENTITY_DB",
+					"url": "jdbc:mysql://DB_HOST:3306/WSO2AGENTIDENTITY_DB?autoReconnect=true&amp;amp;useSSL=false",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				}
@@ -96,13 +116,19 @@
 			"database": [
 				{
 					"name": "WSO2IDENTITY_DB",
-					"url": "jdbc:mysql://DB_HOST:3306/WSO2IDENTITY_DB?permitMysqlScheme&autoReconnect=true&useSSL=false",
+					"url": "jdbc:mysql://DB_HOST:3306/WSO2IDENTITY_DB?permitMysqlScheme&amp;amp;autoReconnect=true&amp;amp;sslMode=trust",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				},
 				{
 					"name": "WSO2SHARED_DB",
-					"url": "jdbc:mysql://DB_HOST:3306/WSO2SHARED_DB?permitMysqlScheme&autoReconnect=true&useSSL=false",
+					"url": "jdbc:mysql://DB_HOST:3306/WSO2SHARED_DB?permitMysqlScheme&amp;amp;autoReconnect=true&amp;amp;sslMode=trust",
+					"username": "DB_USERNAME",
+					"password": "DB_PASSWORD"
+				},
+				{
+					"name": "WSO2AGENTIDENTITY_DB",
+					"url": "jdbc:mysql://DB_HOST:3306/WSO2AGENTIDENTITY_DB?permitMysqlScheme&amp;amp;autoReconnect=true&amp;amp;sslMode=trust",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				}
@@ -111,7 +137,7 @@
 		},
 		{
 			"name": "postgres",
-			"file_name": "postgresql-42.2.14",
+			"file_name": "postgresql-42.7.10",
 			"driver": "org.postgresql.Driver",
             "database": 
             [
@@ -126,13 +152,19 @@
 					"url": "jdbc:postgresql://DB_HOST:5432/WSO2SHARED_DB",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
+				},
+                {
+					"name": "WSO2AGENTIDENTITY_DB",
+					"url": "jdbc:postgresql://DB_HOST:5432/WSO2AGENTIDENTITY_DB",
+					"username": "DB_USERNAME",
+					"password": "DB_PASSWORD"
 				}
 			],
 			"validation_query": "SELECT 1; COMMIT"
 		},
 		{
 			"name": "sqlserver-se",
-			"file_name": "mssql-jdbc-10.2.0.jre8",
+			"file_name": "mssql-jdbc-13.4.0.jre11",
 			"driver": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
             "database": 
             [
@@ -147,25 +179,37 @@
 					"url": "jdbc:sqlserver://DB_HOST:1433;databaseName=WSO2SHARED_DB;SendStringParametersAsUnicode=false;encrypt=false",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
+				},
+                {
+					"name": "WSO2AGENTIDENTITY_DB",
+					"url": "jdbc:sqlserver://DB_HOST:1433;databaseName=WSO2AGENTIDENTITY_DB;SendStringParametersAsUnicode=false;encrypt=false",
+					"username": "DB_USERNAME",
+					"password": "DB_PASSWORD"
 				}
 			],
 			"validation_query": "SELECT 1; COMMIT"
 		},
 		{
 			"name": "oracle-se2",
-			"file_name": "ojdbc8",
+			"file_name": "ojdbc11",
 			"driver": "oracle.jdbc.OracleDriver",
             "database": 
             [
                 {
 					"name": "WSO2IDENTITY_DB",
-					"url": "jdbc:oracle:thin:@DB_HOST:1521/WSO2IDENTITY_DB",
+					"url": "jdbc:oracle:thin:@//DB_HOST:1521/IAMDB",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				},
 				{
 					"name": "WSO2SHARED_DB",
-					"url": "jdbc:oracle:thin:@DB_HOST:1521/WSO2SHARED_DB",
+					"url": "jdbc:oracle:thin:@//DB_HOST:1521/IAMDB",
+					"username": "DB_USERNAME",
+					"password": "DB_PASSWORD"
+				},
+				{
+					"name": "WSO2AGENTIDENTITY_DB",
+					"url": "jdbc:oracle:thin:@//DB_HOST:1521/IAMDB",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				}
@@ -180,13 +224,19 @@
             [
                 {
 					"name": "WSO2IDENTITY_DB",
-					"url": "jdbc:oracle:thin:@DB_HOST:1521/WSO2IDENTITY_DB",
+					"url": "jdbc:oracle:thin:@//DB_HOST:1521/IAMDB",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				},
 				{
 					"name": "WSO2SHARED_DB",
-					"url": "jdbc:oracle:thin:@DB_HOST:1521/WSO2SHARED_DB",
+					"url": "jdbc:oracle:thin:@//DB_HOST:1521/IAMDB",
+					"username": "DB_USERNAME",
+					"password": "DB_PASSWORD"
+				},
+				{
+					"name": "WSO2AGENTIDENTITY_DB",
+					"url": "jdbc:oracle:thin:@//DB_HOST:1521/IAMDB",
 					"username": "DB_USERNAME",
 					"password": "DB_PASSWORD"
 				}

--- a/scripts/is/intg/run-int-test.sh
+++ b/scripts/is/intg/run-int-test.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 Inc. (https://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 Inc. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2
+# expressly. You may not alter or remove any copyright or other notice from
+# copies of this content.
+#
+# ------------------------------------------------------------------------
+
+set -o xtrace
+
+TESTGRID_DIR=/opt/testgrid/workspace
+INFRA_JSON='infra.json'
+PRODUCT_REPOSITORY=$1
+PRODUCT_REPOSITORY_BRANCH=$2
+PRODUCT_NAME="wso2is"
+PRODUCT_VERSION=$4
+GIT_USER=$5
+GIT_PASS=$6
+TEST_MODE=$7
+TEST_GROUP=$8
+PRODUCT_REPOSITORY_NAME=$(echo $PRODUCT_REPOSITORY | rev | cut -d'/' -f1 | rev | cut -d'.' -f1)
+PRODUCT_REPOSITORY_PACK_DIR="$TESTGRID_DIR/$PRODUCT_REPOSITORY_NAME/modules/distribution/target"
+INT_TEST_MODULE_DIR="$TESTGRID_DIR/$PRODUCT_REPOSITORY_NAME/modules/integration/tests-integration"
+
+# CloudFormation properties
+CFN_PROP_FILE="${TESTGRID_DIR}/cfn-props.properties"
+
+JDK_TYPE=$(grep -w "JDK_TYPE" ${CFN_PROP_FILE} | cut -d"=" -f2)
+DB_TYPE=$(grep -w "CF_DBMS_NAME" ${CFN_PROP_FILE} | cut -d"=" -f2)
+PRODUCT_PACK_NAME=$(grep -w "REMOTE_PACK_NAME" ${CFN_PROP_FILE} | cut -d"=" -f2)
+CF_DBMS_VERSION=$(grep -w "CF_DBMS_VERSION" ${CFN_PROP_FILE} | cut -d"=" -f2)
+CF_DB_PASSWORD=$(grep -w "CF_DB_PASSWORD" ${CFN_PROP_FILE} | cut -d"=" -f2)
+CF_DB_USERNAME=$(grep -w "CF_DB_USERNAME" ${CFN_PROP_FILE} | cut -d"=" -f2)
+CF_DB_HOST=$(grep -w "CF_DB_HOST" ${CFN_PROP_FILE} | cut -d"=" -f2)
+CF_DB_PORT=$(grep -w "CF_DB_PORT" ${CFN_PROP_FILE} | cut -d"=" -f2)
+CF_DB_NAME=$(grep -w "SID" ${CFN_PROP_FILE} | cut -d"=" -f2)
+PRODUCT_PACK_LOCATION=$(grep -w "PRODUCT_PACK_LOCATION" ${CFN_PROP_FILE} | cut -d"=" -f2)
+
+function log_info(){
+    echo "[INFO][$(date '+%Y-%m-%d %H:%M:%S')]: $1"
+}
+
+function log_error(){
+    echo "[ERROR][$(date '+%Y-%m-%d %H:%M:%S')]: $1"
+    exit 1
+}
+
+function install_jdk11(){
+    if [[ "$JDK_TYPE" == "ADOPT_OPEN_JDK17_ARM" ]] || [[ "$JDK_TYPE" == "ADOPT_OPEN_JDK21_ARM" ]]; then
+        jdk11="ADOPT_OPEN_JDK11_ARM"
+    else
+        jdk11="ADOPT_OPEN_JDK11"
+    fi
+    mkdir -p /opt/${jdk11}
+    jdk_file2=$(jq -r '.jdk[] | select ( .name == '\"${jdk11}\"') | .file_name' ${INFRA_JSON})
+    wget -q https://integration-testgrid-resources.s3.amazonaws.com/lib/jdk/$jdk_file2.tar.gz
+    tar -xzf "$jdk_file2.tar.gz" -C /opt/${jdk11} --strip-component=1
+
+    export JAVA_HOME=/opt/${jdk11}
+}
+
+function install_jdks(){
+    mkdir -p /opt/${jdk_name}
+    jdk_file=$(jq -r '.jdk[] | select ( .name == '\"${jdk_name}\"') | .file_name' ${INFRA_JSON})
+    wget -q https://integration-testgrid-resources.s3.amazonaws.com/lib/jdk/$jdk_file.tar.gz
+    tar -xzf "$jdk_file.tar.gz" -C /opt/${jdk_name} --strip-component=1
+
+    export JAVA_HOME=/opt/${jdk_name}
+    echo $JAVA_HOME
+}
+
+function set_jdk(){
+    jdk_name=$1
+    #When running Integration tests for JDK 17 or 21, JDK 11 is also required for compilation.
+    if [[ "$jdk_name" == "ADOPT_OPEN_JDK17" ]] || [[ "$jdk_name" == "ADOPT_OPEN_JDK21" ]] || [[ "$jdk_name" == "ADOPT_OPEN_JDK17_ARM" ]] || [[ "$jdk_name" == "ADOPT_OPEN_JDK21_ARM" ]]; then
+        echo "Installing " + $jdk_name
+        install_jdks
+        echo $JAVA_HOME
+        #setting JAVA_HOME to JDK 11 to compile
+        install_jdk11
+        echo $JAVA_HOME 
+    elif [[ "$jdk_name" == "ADOPT_OPEN_JDK8" ]]; then
+        echo "Installing " + $jdk_name
+        install_jdks
+        echo $JAVA_HOME
+    else
+        echo "Installing " + $jdk_name
+        install_jdks
+        echo $JAVA_HOME
+        
+    fi
+}
+
+function get_db_type() {
+    local db_name=$1
+    case "$db_name" in
+        oracle-se2|oracle-se2-cdb) echo "oracle" ;;
+        postgres) echo "postgresql" ;;
+        sqlserver-se) echo "mssql" ;;
+        db2-se) echo "db2" ;;
+        *) echo "$db_name" ;;
+    esac
+}
+
+function update_test_pom_db_config() {
+    local db_name=$1
+    local pom_file="$INT_TEST_MODULE_DIR/tests-backend/pom.xml"
+
+    local db_type driver validation_query
+    local identity_url identity_username identity_password
+    local shared_url shared_username shared_password
+    local agentidentity_url agentidentity_username agentidentity_password
+
+    db_type=$(get_db_type "$db_name")
+    driver=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .driver' "${INFRA_JSON}")
+    validation_query=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .validation_query' "${INFRA_JSON}")
+
+    identity_url=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2IDENTITY_DB") | .url' "${INFRA_JSON}")
+    identity_username=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2IDENTITY_DB") | .username' "${INFRA_JSON}")
+    identity_password=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2IDENTITY_DB") | .password' "${INFRA_JSON}")
+
+    shared_url=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2SHARED_DB") | .url' "${INFRA_JSON}")
+    shared_username=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2SHARED_DB") | .username' "${INFRA_JSON}")
+    shared_password=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2SHARED_DB") | .password' "${INFRA_JSON}")
+
+    agentidentity_url=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2AGENTIDENTITY_DB") | .url' "${INFRA_JSON}")
+    agentidentity_username=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2AGENTIDENTITY_DB") | .username' "${INFRA_JSON}")
+    agentidentity_password=$(jq -r --arg db "$db_name" '.jdbc[] | select(.name == $db) | .database[] | select(.name == "WSO2AGENTIDENTITY_DB") | .password' "${INFRA_JSON}")
+
+    log_info "Injecting test-backend/pom.xml environment variables for ${db_name} (type: ${db_type})"
+
+    # Write the <environmentVariables> block to a temp file, then inject it into
+    # the testgrid profile of pom.xml (between </systemProperties> and <workingDirectory>)
+    local tmp_env_vars
+    tmp_env_vars=$(mktemp)
+    cat > "$tmp_env_vars" << XML
+                            <environmentVariables>
+                                <IDENTITY_DATABASE_TYPE>${db_type}</IDENTITY_DATABASE_TYPE>
+                                <IDENTITY_DATABASE_DRIVER>${driver}</IDENTITY_DATABASE_DRIVER>
+                                <IDENTITY_DATABASE_URL>${identity_url}</IDENTITY_DATABASE_URL>
+                                <IDENTITY_DATABASE_USERNAME>${identity_username}</IDENTITY_DATABASE_USERNAME>
+                                <IDENTITY_DATABASE_PASSWORD>${identity_password}</IDENTITY_DATABASE_PASSWORD>
+                                <IDENTITY_DATABASE_VALIDATION_QUERY>${validation_query}</IDENTITY_DATABASE_VALIDATION_QUERY>
+                                <SHARED_DATABASE_TYPE>${db_type}</SHARED_DATABASE_TYPE>
+                                <SHARED_DATABASE_DRIVER>${driver}</SHARED_DATABASE_DRIVER>
+                                <SHARED_DATABASE_URL>${shared_url}</SHARED_DATABASE_URL>
+                                <SHARED_DATABASE_USERNAME>${shared_username}</SHARED_DATABASE_USERNAME>
+                                <SHARED_DATABASE_PASSWORD>${shared_password}</SHARED_DATABASE_PASSWORD>
+                                <SHARED_DATABASE_VALIDATION_QUERY>${validation_query}</SHARED_DATABASE_VALIDATION_QUERY>
+                                <AGENTIDENTITY_DATABASE_TYPE>${db_type}</AGENTIDENTITY_DATABASE_TYPE>
+                                <AGENTIDENTITY_DATABASE_DRIVER>${driver}</AGENTIDENTITY_DATABASE_DRIVER>
+                                <AGENTIDENTITY_DATABASE_URL>${agentidentity_url}</AGENTIDENTITY_DATABASE_URL>
+                                <AGENTIDENTITY_DATABASE_USERNAME>${agentidentity_username}</AGENTIDENTITY_DATABASE_USERNAME>
+                                <AGENTIDENTITY_DATABASE_PASSWORD>${agentidentity_password}</AGENTIDENTITY_DATABASE_PASSWORD>
+                                <AGENTIDENTITY_DATABASE_VALIDATION_QUERY>${validation_query}</AGENTIDENTITY_DATABASE_VALIDATION_QUERY>
+                            </environmentVariables>
+XML
+
+    awk -v env_file="$tmp_env_vars" '
+        BEGIN { in_integration = 0; in_env_vars = 0; injected = 0 }
+        /<id>integration<\/id>/ { in_integration = 1 }
+        /<environmentVariables>/ && in_integration {
+            in_env_vars = 1
+            while ((getline line < env_file) > 0) print line
+            injected = 1
+            next
+        }
+        /<\/environmentVariables>/ && in_env_vars {
+            in_env_vars = 0
+            in_integration = 0
+            next
+        }
+        in_env_vars { next }
+        { print }
+        END { if (!injected) { print "ERROR: Could not replace environment variables in integration profile" > "/dev/stderr"; exit 1 } }
+    ' "$pom_file" > "${pom_file}.tmp"
+    awk_status=$?
+    if [ $awk_status -ne 0 ] || ! mv "${pom_file}.tmp" "$pom_file"; then
+        rm -f "${pom_file}.tmp"
+        log_error "Failed to inject environment variables into testgrid profile"
+    fi
+
+    rm -f "$tmp_env_vars"
+}
+
+source /etc/environment
+
+log_info "Clone Product repository"
+if [ ! -d $PRODUCT_REPOSITORY_NAME ];
+then
+    git clone https://${GIT_USER}:${GIT_PASS}@$PRODUCT_REPOSITORY --branch $PRODUCT_REPOSITORY_BRANCH --single-branch
+fi
+
+
+wget -q "https://raw.githubusercontent.com/wos2/testgrid-jenkins-library/refs/heads/main/scripts/is/intg/infra.json"
+log_info "Exporting JDK"
+set_jdk ${JDK_TYPE}
+
+pwd
+db_file=$(jq -r '.jdbc[] | select ( .name == '\"${DB_TYPE}\"') | .file_name' ${INFRA_JSON})
+wget -q https://integration-testgrid-resources.s3.amazonaws.com/lib/jdbc/${db_file}.jar  -P $TESTGRID_DIR/${PRODUCT_PACK_NAME}/repository/components/lib
+
+
+sed -i "s|DB_HOST|${CF_DB_HOST}|g" ${INFRA_JSON}
+sed -i "s|DB_USERNAME|${CF_DB_USERNAME}|g" ${INFRA_JSON}
+sed -i "s|DB_PASSWORD|${CF_DB_PASSWORD}|g" ${INFRA_JSON}
+sed -i "s|DB_NAME|${DB_NAME}|g" ${INFRA_JSON}
+
+update_test_pom_db_config "${DB_TYPE}"
+
+# delete if the folder is available
+rm -rf $PRODUCT_REPOSITORY_PACK_DIR
+mkdir -p $PRODUCT_REPOSITORY_PACK_DIR
+log_info "Copying product pack to Repository"
+ls $TESTGRID_DIR
+rm -rf $TESTGRID_DIR/$PRODUCT_NAME-$PRODUCT_VERSION.zip
+ls $TESTGRID_DIR
+
+# Update deployment.toml in the pack with $env{} placeholders for database configuration
+log_info "Updating deployment.toml with environment variable placeholders"
+wget -q https://raw.githubusercontent.com/Miranlfk/is-test-integration/refs/heads/master/update_db_configs.sh
+cp update_db_configs.sh $TESTGRID_DIR/
+bash $TESTGRID_DIR/update_db_configs.sh $DB_TYPE $PRODUCT_NAME-$PRODUCT_VERSION
+
+# Re-zip the pack after configuration updates
+log_info "Re-zipping product pack with updated configurations"
+zip -q -r $TESTGRID_DIR/$PRODUCT_NAME-$PRODUCT_VERSION.zip $PRODUCT_NAME-$PRODUCT_VERSION
+
+log_info "Navigating to integration test module directory"
+ls $INT_TEST_MODULE_DIR
+
+# Check for master branch execution or tag-based execution
+if [[ "$PRODUCT_VERSION" != *"SNAPSHOT"* ]]; then
+    cd $TESTGRID_DIR/$PRODUCT_REPOSITORY_NAME || log_error "Failed to navigate to product repository directory"
+    echo $JAVA_HOME
+    #If support add the nexus repository to the pom.xml
+    if [[ "$PRODUCT_REPOSITORY_BRANCH" == *"support"* ]]; then
+        cp $TESTGRID_DIR/add_patch_repository.sh $TESTGRID_DIR/$PRODUCT_REPOSITORY_NAME
+        log_info "Add WSO2 repository to pom.xml"
+        cd $TESTGRID_DIR/$PRODUCT_REPOSITORY_NAME/
+        bash add_patch_repository.sh
+        if [[ "$PRODUCT_VERSION" == "5.11.0" ]]; then
+            cd $TESTGRID_DIR/$PRODUCT_REPOSITORY_NAME
+            find . -name "*.toml" -type f -exec sed -i.bak '
+            /^\[user_store\]/,/^\[/ {
+                s/^type = "read_write_ldap_unique_id"$/type = "database_unique_id"/
+                s/^connection_url = "ldap:\/\/localhost:\${Ports\.EmbeddedLDAP\.LDAPServerPort}"$/#connection_url = "ldap:\/\/localhost:${Ports.EmbeddedLDAP.LDAPServerPort}"/
+                s/^connection_name = "uid=admin,ou=system"$/#connection_name = "uid=admin,ou=system"/
+                s/^connection_password = "admin"$/#connection_password = "admin"/
+                s/^base_dn = "dc=wso2,dc=org".*$/#&/
+            }
+            ' {} \;
+
+            find . -name "*.toml" -type f -exec sh -c 'echo "=== $1 ===" && grep -A 6 "^\[user_store\]" "$1" && echo ""' sh {} \;
+        fi
+    fi
+    log_info "Running Maven clean install"
+    #For Tag-based execution we initially build the product pack and then run the integration tests
+    cd $TESTGRID_DIR/$PRODUCT_REPOSITORY_NAME
+    echo $JAVA_HOME
+    if [[ "$PRODUCT_VERSION" == *"7.3.0"* ]]; then
+        export JAVA_HOME=/opt/${jdk_name}
+    fi
+    mvn clean install -Dmaven.test.skip=true -U
+    ls $PRODUCT_REPOSITORY_PACK_DIR
+    echo "Copying pack to target"
+    mv $TESTGRID_DIR/$PRODUCT_NAME-$PRODUCT_VERSION.zip $PRODUCT_REPOSITORY_PACK_DIR/$PRODUCT_NAME-$PRODUCT_VERSION.zip
+    ls $PRODUCT_REPOSITORY_PACK_DIR
+    cd $INT_TEST_MODULE_DIR || log_error "Failed to navigate to integration test module directory"
+    log_info "Running Maven clean install"
+    export JAVA_HOME=/opt/${jdk_name}
+    echo $JAVA_HOME
+    mvn clean install
+else 
+    if [[ "$PRODUCT_VERSION" == *"7.3.0"* ]]; then
+        export JAVA_HOME=/opt/${jdk_name}
+    fi
+    echo "Copying pack to target"
+    mv $TESTGRID_DIR/$PRODUCT_NAME-$PRODUCT_VERSION.zip $PRODUCT_REPOSITORY_PACK_DIR/$PRODUCT_NAME-$PRODUCT_VERSION.zip
+    ls $PRODUCT_REPOSITORY_PACK_DIR
+    cd $INT_TEST_MODULE_DIR || log_error "Failed to navigate to integration test module directory"
+    log_info "Running Maven clean install"
+    mvn clean install -U
+fi


### PR DESCRIPTION
## Purpose

This pull request introduces two new helper scripts to automate and standardize database and repository configuration tasks for WSO2 Identity Server integration. The first script, `add_patch_repository.sh`, ensures the WSO2 Nexus repository is correctly added to the Maven `pom.xml` file and fixes any malformed repository name tags. The second script, `consolidate_db_is.sh`, generates database creation and schema scripts for various supported database engines, consolidating consent schemas into the identity database scripts for easier setup.

**Repository configuration automation:**

* Added `add_patch_repository.sh` to automate adding the WSO2 Nexus repository to the `pom.xml`, including logic to fix incorrect `<n>` tags to `<name>` in repository sections and to avoid duplicate repository entries.

**Database script consolidation:**

* Added `consolidate_db_is.sh` to generate database creation and schema scripts for multiple database engines (PostgreSQL, MySQL, MariaDB, SQL Server, Oracle, and DB2), with logic to merge consent schemas into identity schemas for simplified deployment.
