### PR TITLE
Add APIM 4.7.0 helm chart compatibility and registry-race mitigation

### DIFF
--- a/integration-v2.groovy
+++ b/integration-v2.groovy
@@ -36,8 +36,8 @@ String awsCred = params.awsCred
 String dbPassword = params.dbPassword
 String project = params.project?: "wso2"
 String apimPackS3Bucket = params.apimPackS3Bucket
-String dockerRepoBranch = params.dockerRepoBranch ?: "4.5.x"
-String helmRepoBranch = params.helmRepoBranch ?: "4.5.x"
+String dockerRepoBranch = params.dockerRepoBranch ?: "4.7.x"
+String helmRepoBranch = params.helmRepoBranch ?: "4.7.x"
 Boolean onlyDestroyResources = params.onlyDestroyResources
 Boolean destroyResources = params.destroyResources
 Boolean skipTfApply = params.skipTfApply
@@ -45,6 +45,7 @@ Boolean skipDockerBuild = params.skipDockerBuild
 Boolean skipTests = params.skipTests
 Boolean skipUpdate = params.skipUpdate ?: false
 Boolean skipPeerTest = params.skipPeerTest
+String encryptionKey = params.encryptionKey ?: ""
 
 // Default values
 def deploymentPatterns = []
@@ -792,6 +793,9 @@ pipeline {
 
                                         # Wait for nginx to come alive.
                                         kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=480s ||  { echo 'Nginx service is not ready within the expected time limit.';  exit 1; }
+
+                                        # Install Kubernetes Gateway API CRDs required by helm-apim 4.7.x
+                                        kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
                                     """
 
                                     def hostName = sh(script: "kubectl -n ingress-nginx get svc ingress-nginx-controller -o json | jq -r '.status.loadBalancer.ingress[0].hostname'", returnStdout: true).trim()
@@ -1067,6 +1071,9 @@ pipeline {
                                                             --set wso2.apim.configurations.gateway.environments[0].websubHostname="${websubHost}" \
                                                             --set wso2.apim.configurations.devportal.enableApplicationSharing=true \
                                                             --set wso2.apim.configurations.devportal.applicationSharingType="default" \
+                                                            --set wso2.apim.configurations.encryption.key="${encryptionKey}" \
+                                                            --set kubernetes.gatewayAPI.enabled=false \
+                                                            --set kubernetes.ingress.controlPlane.enabled=true \
                                                             --set wso2.apim.configurations.oauth_config.oauth2JWKSUrl="https://apim-acp-wso2am-acp-service:9443/oauth2/jwks" \
                                                             --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
                                                             --set wso2.deployment.image.repository="${project}-wso2am-acp:${acpImageTag}" \
@@ -1083,9 +1090,21 @@ pipeline {
                                                             --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
                                                             --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}"
                                                         
-                                                        # Wait for the deployment to be ready
+                                                        # Stagger ACP replica startup. Both replicas race to insert
+                                                        # REG_PATH rows for /_system/governance/event into the shared
+                                                        # DB at boot; the loser gets FK violations that permanently
+                                                        # break EventBroker for that pod.
+                                                        kubectl --context=${patternDirSafe} scale deployment/apim-acp-wso2am-acp-deployment-2 --replicas=0 -n ${namespace}
                                                         kubectl --context=${patternDirSafe} wait --for=condition=available --timeout=400s deployment/apim-acp-wso2am-acp-deployment-1 -n ${namespace}
+                                                        sleep 30
+                                                        kubectl --context=${patternDirSafe} scale deployment/apim-acp-wso2am-acp-deployment-2 --replicas=1 -n ${namespace}
                                                         kubectl --context=${patternDirSafe} wait --for=condition=available --timeout=400s deployment/apim-acp-wso2am-acp-deployment-2 -n ${namespace}
+
+                                                        # Carbon's readiness probe passes before EventBroker finishes
+                                                        # writing /_system/governance/event registry paths. Give the
+                                                        # ACPs a grace period before TM joins, otherwise TM-1 races
+                                                        # the still-finalizing ACP and hits the same FK violations.
+                                                        sleep 60
 
                                                         # Deploy wso2am-tm (variant: ${dpSafe.tmVariant})
                                                         echo "Deploying WSO2 API Manager - Traffic Manager [${dpSafe.tmVariant}] in ${namespace} namespace..."
@@ -1106,6 +1125,7 @@ pipeline {
                                                             --set wso2.apim.configurations.eventhub.enabled=true \
                                                             --set wso2.apim.configurations.eventhub.serviceUrl="apim-acp-wso2am-acp-service" \
                                                             --set wso2.apim.configurations.eventhub.urls="{apim-acp-wso2am-acp-1-service,apim-acp-wso2am-acp-2-service}" \
+                                                            --set wso2.apim.configurations.encryption.key="${encryptionKey}" \
                                                             --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
                                                             --set wso2.deployment.image.repository="${project}-wso2am-tm:${tmImageTag}" \
                                                             --set wso2.deployment.image.digest=${wso2amTmImageDigest} \
@@ -1121,9 +1141,17 @@ pipeline {
                                                             --set wso2.apim.configurations.databases.shared_db.username="${dbUser}" \
                                                             --set wso2.apim.configurations.databases.shared_db.password="${dbPassword}"
 
-                                                        # Wait for the deployment to be ready
+                                                        # Same registry-race mitigation as ACP — stagger TM replicas
+                                                        # so they don't both race to register the throttledata topic.
+                                                        kubectl --context=${patternDirSafe} scale deployment/apim-tm-wso2am-tm-deployment-2 --replicas=0 -n ${namespace}
                                                         kubectl --context=${patternDirSafe} wait --for=condition=available --timeout=400s deployment/apim-tm-wso2am-tm-deployment-1 -n ${namespace}
+                                                        sleep 30
+                                                        kubectl --context=${patternDirSafe} scale deployment/apim-tm-wso2am-tm-deployment-2 --replicas=1 -n ${namespace}
                                                         kubectl --context=${patternDirSafe} wait --for=condition=available --timeout=400s deployment/apim-tm-wso2am-tm-deployment-2 -n ${namespace}
+
+                                                        # Same grace as after ACP — let TM finalize throttledata
+                                                        # topic registration before GW pods start subscribing.
+                                                        sleep 60
 
                                                         # Deploy wso2am-gw (variant: ${dpSafe.gwVariant})
                                                         echo "Deploying WSO2 API Manager - Gateway [${dpSafe.gwVariant}] in ${namespace} namespace..."
@@ -1140,8 +1168,12 @@ pipeline {
                                                             --set wso2.apim.configurations.security.keystores.internal.keyPassword="wso2carbon" \
                                                             --set wso2.apim.configurations.security.truststore.password="wso2carbon" \
                                                             --set wso2.deployment.resources.requests.cpu="1000m" \
+                                                            --set kubernetes.gatewayAPI.enabled=false \
+                                                            --set kubernetes.ingress.gateway.enabled=true \
                                                             --set kubernetes.ingress.gateway.hostname="${gwHost}" \
+                                                            --set kubernetes.ingress.websocket.enabled=true \
                                                             --set kubernetes.ingress.websocket.hostname="${wsHost}" \
+                                                            --set kubernetes.ingress.websub.enabled=true \
                                                             --set kubernetes.ingress.websub.hostname="${websubHost}" \
                                                             --set wso2.apim.configurations.km.serviceUrl="apim-acp-wso2am-acp-service" \
                                                             --set wso2.apim.configurations.throttling.serviceUrl="apim-tm-wso2am-tm-service" \
@@ -1149,6 +1181,7 @@ pipeline {
                                                             --set wso2.apim.configurations.eventhub.enabled=true \
                                                             --set wso2.apim.configurations.eventhub.serviceUrl="apim-acp-wso2am-acp-service" \
                                                             --set wso2.apim.configurations.eventhub.urls="{apim-acp-wso2am-acp-1-service,apim-acp-wso2am-acp-2-service}" \
+                                                            --set wso2.apim.configurations.encryption.key="${encryptionKey}" \
                                                             --set wso2.deployment.image.registry="${dockerRegistrySafe}" \
                                                             --set wso2.deployment.image.repository="${project}-wso2am-universal-gw:${gwImageTag}" \
                                                             --set wso2.deployment.image.digest=${wso2amGwImageDigest} \
@@ -1218,9 +1251,12 @@ pipeline {
 
                                                     // All HTTP endpoints are reachable, but under heavy
                                                     // parallel load internal JMS/EventHub subscriber threads
-                                                    // may still be catching up.
-                                                    echo "All HTTP endpoints are ready. Waiting 60s for internal JMS/EventHub sync..."
-                                                    sleep 60
+                                                    // may still be catching up. In peer-test mode 4 namespaces
+                                                    // share the same EKS cluster, so the slowest pattern can
+                                                    // exceed the single-pattern sync budget.
+                                                    int jmsSyncWaitSeconds = (peerTestPatterns.size() > 1) ? 180 : 60
+                                                    echo "All HTTP endpoints are ready. Waiting ${jmsSyncWaitSeconds}s for internal JMS/EventHub sync..."
+                                                    sleep jmsSyncWaitSeconds
 
                                                     sh """#!/bin/bash
                                                         set +e


### PR DESCRIPTION
## Purpose
The APIM470 pipeline could not deploy the 4.7.0 distributed pack because helm-apim 4.7.x changes several chart defaults that `integration-v2.groovy` did not account for:
- A new required value `wso2.apim.configurations.encryption.key`.
- `kubernetes.gatewayAPI.enabled` defaults to **true** (requires Kubernetes Gateway API CRDs installed in the cluster, which 4.5/4.6 didn't need).
- `kubernetes.ingress.{controlPlane,gateway,websocket,websub}.enabled` defaults to **false** and must be explicitly enabled.

Once those were addressed, the throttling test still flaked under the 4.7.0 peer-test matrix. Pod logs from failing runs showed TM pods hitting `REG_RESOURCE` foreign-key violations on `/_system/governance/event` during startup, after which the Andes broker permanently rejected all GW bind attempts on the `throttledata` topic with **403: access refused**. Root cause is a race between Carbon nodes bootstrapping the same shared-DB registry paths concurrently.

Resolves the APIM470 pipeline enablement and the related throttling flake observed in [Run 8](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/8/) and [Run 10](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/10/).

## Goals
- Make `integration-v2.groovy` deploy APIM 4.7.0 successfully across the full peer-test matrix.
- Eliminate the registry-bootstrap race so the throttling test is stable.
- Preserve backward compatibility with the APIM450 and APIM460 jobs that share this pipeline.

## Approach
**4.7.x helm-chart compatibility**
- Add an optional `encryptionKey` job parameter (default `""`).
- Apply Gateway API CRDs (`v1.1.0/standard-install.yaml`) after nginx is up.
- Thread new `--set` overrides through ACP / TM / GW helm installs: `encryption.key`, `gatewayAPI.enabled=false`, and the four `ingress.*.enabled=true` flags.

**Registry-race mitigation**
- Stagger each component's two replica deployments: after `helm install`, scale `deployment-2` to 0, wait for `deployment-1` to be available, sleep 30s, then scale `deployment-2` back to 1.
- 60s grace between ACP→TM and TM→GW helm installs. Carbon's K8s readiness probe passes before EventBroker finishes committing registry paths to the DB, so the next component needs a real wait window, not just a probe pass.
- JMS/EventHub sync sleep is now adaptive: 180s in peer-test mode (4 namespaces share a cluster), 60s otherwise.

**Backward compatibility with APIM450 / APIM460**
- The new `--set` overrides are no-ops on 4.5.x and 4.6.x: `encryption.key` doesn't exist there (helm `--set` to an unreferenced path is silently ignored by chart templates), and the `gatewayAPI` / `ingress` flags already match the existing defaults in those chart versions.
- The default branch bump (`4.5.x` → `4.7.x`) is moot because both APIM450 and APIM460 jobs pass `dockerRepoBranch`/`helmRepoBranch` explicitly.
- Stagger targets the same deployment names that already exist in upstream `apim-main`, so it works unchanged on 4.5/4.6.
- Net cost on older jobs: ~+4–5 min wall-clock per pattern, all in fixed sleeps and replica staggering. No behavioral change.

## User stories
> N/A — pipeline-only change with no user-facing surface.

## Release note
> APIM 4.7.0 integration pipeline (`integration-v2.groovy`) now supports the helm-apim 4.7.x chart defaults and applies a startup stagger that prevents the Carbon registry FK race responsible for intermittent throttling test failures.

## Documentation
> N/A — internal pipeline change; no product documentation impact.

## Training
> N/A — internal CI tooling.

## Certification
> N/A — no certifiable behavior changed.

## Marketing
> N/A — internal CI tooling.

## Automation tests
- Unit tests
  > N/A — Groovy pipeline script with no unit-testable units; validated through end-to-end pipeline runs.
- Integration tests
  > Full 4-pattern peer-test matrix exercised on `APIM470`. Throttling failures stopped after applying the fix:
  >
  > | Pipeline run | Result | TM-1 FK errors | GW bind denials |
  > |--------------|--------|----------------|-----------------|
  > | Pre-fix ([Run 8](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/8/), acp-staging) | FAIL | 143 | 1268 |
  > | Stagger only ([Run 10](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/10/), all-staging) | FAIL | 368 | 600 |
  > | Stagger + grace ([Run 13](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/13/), all 4 patterns) | **PASS** | **0** | **0** |
  > | Stagger + grace ([Run 14](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/14/), all 4 patterns) | **PASS** | **0** | **0** |
  >
  > Pod-log audit on [Run 13](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/13/) artifacts confirms zero FK errors and zero Andes `binding throttledata` denials across every TM and GW pod, in every pattern.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — pipeline Groovy script, not a Java compilation target.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
> N/A — internal pipeline change.

## Related PRs
> N/A.

## Migrations (if applicable)
> N/A — pipeline-side change only; no on-cluster or DB migrations.

## Test environment
- Kubernetes: EKS, `us-east-2`, kubernetes version 1.33
- OS: Ubuntu
- JDK: ADOPT_OPEN_JDK21 (APIM 4.7.0)
- Database: MySQL 8.0.43
- APIM versions exercised by this pipeline change: 4.7.0 (primary); 4.5.x and 4.6.x verified for non-regression by static analysis of chart values and pipeline-side helm `--set` semantics.

## Learning
- Initial hypothesis was a deterministic schema-version mismatch between ACP-latest and TM-ga in the `acp-staging` peer pattern. Comparing pod logs between [Run 7](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/7/) (SUCCESS, same variant combo) and [Run 8](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/8/) (FAILURE) disproved that — Run 7's `acp-staging` namespace had zero FK errors. The cause was instead a stochastic registry-bootstrap race.
- First mitigation (stagger replicas only) was insufficient — [Run 10](https://testgrid.wso2.com/job/Kubernetes-deployments/job/APIM/job/APIM470/10/) showed the race shift from within-component (deployment-1 vs deployment-2) to cross-component (TM-1 racing an ACP still finalizing its EventBroker registry writes after the readiness probe had passed). The grace sleeps were added to close that second window.
- Useful pattern for diagnosing this class of issue: pair the Jenkins console log (which surfaces *what* test assertion failed) with the per-pod archive logs (which reveal *why* the underlying subsystem was broken) — the latter exposed the FK chain that the former couldn't.
