### PR TITLE
Harden phase-split test flow: guarantee teardown and fail phases honestly

### DIFF
--- a/integration.groovy
+++ b/integration.groovy
@@ -255,7 +255,13 @@ def executeTests(deploymentDirectory, productTestGroup) {
         }
     } finally {
         stage("Teardown [${label}]") {
-            runTestPhase(deploymentDirectory, productTestGroup, "collect")
+            // Report collection is best-effort: a collect failure must never block
+            // the teardown below, or the stack would leak until the post-build sweep.
+            try {
+                runTestPhase(deploymentDirectory, productTestGroup, "collect")
+            } catch (err) {
+                println "Report collection failed for ${label} (best-effort, continuing to teardown): ${err}"
+            }
             runTestPhase(deploymentDirectory, productTestGroup, "teardown")
         }
     }

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -72,6 +72,19 @@ function writeJsonFile(){
     done
 }
 
+# 8-char alphanumeric suffix used to keep resource names (e.g. stack names) unique.
+# LC_ALL=C keeps tr from choking on urandom bytes under UTF-8 locales.
+function generateRandomString(){
+    LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo ''
+}
+
+# Sanitize a value for use inside CloudFormation stack names, which only allow
+# [a-zA-Z][-a-zA-Z0-9]*. Whitelist rather than strip known-bad characters.
+function removeSpecialCharacters(){
+    local stringValue=$1
+    echo "${stringValue}" | sed 's|[^A-Za-z0-9-]||g'
+}
+
 # Logging functions
 function log_info() {
     local string=$@

--- a/scripts/deployment-builder.sh
+++ b/scripts/deployment-builder.sh
@@ -31,16 +31,6 @@ osArray=(`echo ${os_list} | sed 's/,/\n/g'`)
 jdkArray=(`echo ${jdk_list} | sed 's/,/\n/g'`)
 dbArray=(`echo ${database_list} | sed 's/,/\n/g'`)
 
-function generateRandomString(){
-    tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo ''
-}
-
-function removeSpecialCharacters(){
-    stringValue=$1
-    removedString=$(echo "${stringValue}" | sed 's|[_.,]||g' )
-    echo ${removedString}
-}
-
 echo "Creating the deployment directories by using infrastructure combination!"
 for os in ${osArray[@]}; do
     for jdk in ${jdkArray[@]}; do

--- a/scripts/intg-test-deployment.sh
+++ b/scripts/intg-test-deployment.sh
@@ -24,7 +24,8 @@
 #   clone       - clone the product test repo onto the slave
 #   setup|update|provisiondb|test|collect - delegated to intg-test-executer.sh
 #   teardown    - run post actions (stack deletion / log handling)
-#   ""|all      - clone, run the whole executer flow, then post actions (legacy default)
+#   ""|all      - clone, run the whole executer flow, then post actions (legacy default;
+#                 not used by the pipeline, kept for manual invocation)
 # --------------------------------------------------------------------------------------
 
 deploymentName=$1
@@ -57,8 +58,8 @@ function cloneTestRepo(){
       git -C ${deploymentDirectory} clone ${cloneString} --branch ${productTestBranch}
       if [[ $? != 0 ]];
         then
+          # Teardown is owned by the pipeline's Teardown stage - just fail the phase.
           log_error "Testing repo clone failed! Please check if the Git credentials or the test repo name is correct."
-          bash ${currentScript}/post-actions.sh ${deploymentName}
           exit 1
         else
           log_info "Cloning the test repo was successfull!"
@@ -94,7 +95,8 @@ function runPostActions(){
 }
 
 # Legacy combined flow: prepare outputs, run every executer phase, then post actions
-# regardless of the test result.
+# regardless of the test result. NOT used by the pipeline (integration.groovy always
+# passes an explicit phase) - kept only for manual invocation.
 function deploymentTest(){
     prepareOutputDir
     runExecuterPhase "all"
@@ -124,7 +126,7 @@ function main(){
             runExecuterPhase "test" || exit 1 ;;
         collect)
             # Best-effort report collection; never fail the build for this.
-            runExecuterPhase "collect" ;;
+            runExecuterPhase "collect" || log_info "Report collection failed (best-effort); continuing" ;;
         teardown)
             runPostActions ;;
         ""|all)

--- a/scripts/intg-test-executer.sh
+++ b/scripts/intg-test-executer.sh
@@ -83,15 +83,18 @@ SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${keyFi
 MVNSTATE=1
 
 function phaseSetup(){
-    wget -q ${SCRIPT_LOCATION}
-    aws s3 cp 's3://integration-testgrid-resources/testgrid-key.pem' ${keyFileLocation}
-    chmod 400 ${keyFileLocation}
+    # Download into the per-deployment inputs dir (absolute path) - parallel group
+    # branches share the workspace CWD, so a bare wget here would race on one file.
+    local testScriptFile="${INPUTS_DIR}/${TEST_SCRIPT_NAME}"
+    wget -q -O "${testScriptFile}" ${SCRIPT_LOCATION} || { log_error "Downloading test script ${SCRIPT_LOCATION} failed"; return 1; }
+    aws s3 cp 's3://integration-testgrid-resources/testgrid-key.pem' ${keyFileLocation} || { log_error "Downloading testgrid key from S3 failed"; return 1; }
+    chmod 400 ${keyFileLocation} || { log_error "Setting permissions on ${keyFileLocation} failed"; return 1; }
 
     log_info "Copying ${TEST_SCRIPT_NAME} to remote ec2 instance"
-    scp ${SSH_OPTS} ${TEST_SCRIPT_NAME} $instanceUser@${WSO2InstanceName}:/opt/testgrid/workspace/${TEST_SCRIPT_NAME}
+    scp ${SSH_OPTS} ${testScriptFile} $instanceUser@${WSO2InstanceName}:/opt/testgrid/workspace/${TEST_SCRIPT_NAME} || { log_error "Copying ${TEST_SCRIPT_NAME} to remote instance failed"; return 1; }
 
     log_info "Copying ${INFRA_JSON} to remote ec2 instance"
-    scp ${SSH_OPTS} ${INFRA_JSON} $instanceUser@${WSO2InstanceName}:/opt/testgrid/workspace/infra.json
+    scp ${SSH_OPTS} ${INFRA_JSON} $instanceUser@${WSO2InstanceName}:/opt/testgrid/workspace/infra.json || { log_error "Copying ${INFRA_JSON} to remote instance failed"; return 1; }
 }
 
 function phaseUpdate(){
@@ -136,12 +139,15 @@ case "${phase}" in
     collect)
         phaseCollect ;;
     all)
+        # NOT used by the pipeline (intg-test-deployment.sh always passes a single
+        # phase) - kept for manual invocation.
         phaseSetup
         phaseUpdate
         phaseProvisionDb
         phaseTest
-        # Reports are collected even on test failure, then the status is enforced.
-        phaseCollect
+        # Reports are collected (best-effort) even on test failure, then the status
+        # is enforced.
+        phaseCollect || log_info "Report collection failed (best-effort); continuing"
         [[ ${MVNSTATE} != 0 ]] && exit 1
         exit 0 ;;
     *)

--- a/scripts/parameter-file-handler.sh
+++ b/scripts/parameter-file-handler.sh
@@ -21,6 +21,7 @@
 product=$1
 productVersion=$2
 updateLevel=$3
+currentScript=$(dirname $(realpath "$0"))
 source ${currentScript}/common-functions.sh
 
 originalParameteFilePath="${WORKSPACE}/parameters/parameters.json"
@@ -30,16 +31,6 @@ testType=$(extractParameters "TestType" ${parameterFilePath})
 osArray=(`echo ${os_list} | sed 's/,/\n/g'`)
 jdkArray=(`echo ${jdk_list} | sed 's/,/\n/g'`)
 dbArray=(`echo ${database_list} | sed 's/,/\n/g'`)
-
-function generateRandomString(){
-    tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo ''
-}
-
-function removeSpecialCharacters(){
-    stringValue=$1
-    removedString=$(echo "${stringValue}" | sed 's|[_.,]||g' )
-    echo ${removedString}
-}
 
 for os in ${osArray[@]}; do
     for jdk in ${jdkArray[@]}; do

--- a/scripts/prepare-group-deployment.sh
+++ b/scripts/prepare-group-deployment.sh
@@ -36,23 +36,17 @@ source ${currentScript}/common-functions.sh
 baseDeploymentDir="${WORKSPACE}/deployment/${baseDeploymentName}"
 baseParameterFile="${baseDeploymentDir}/parameters.json"
 
-function generateRandomString(){
-    tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo ''
-}
-
-function removeSpecialCharacters(){
-    local stringValue=$1
-    echo "${stringValue}" | sed 's|[_.,/ ]||g'
-}
-
 sanitizedGroup=$(removeSpecialCharacters "${testGroup}")
 groupDeploymentName="${baseDeploymentName}-${sanitizedGroup}"
 groupDeploymentDir="${WORKSPACE}/deployment/${groupDeploymentName}"
 groupParameterFile="${groupDeploymentDir}/parameters.json"
 
-# An isolated directory + parameter file is created per test group
-mkdir -p "${groupDeploymentDir}"
-cp "${baseParameterFile}" "${groupParameterFile}"
+# An isolated directory + parameter file is created per test group. Every step below
+# must succeed - a partially prepared directory would leave this group running against
+# the base combination's StackName, colliding with the other groups' deployments and
+# teardown. The Jenkins caller checks the exit code, so fail hard instead.
+mkdir -p "${groupDeploymentDir}" || { log_error "Creating group deployment directory ${groupDeploymentDir} failed"; exit 1; }
+cp "${baseParameterFile}" "${groupParameterFile}" || { log_error "Copying base parameter file ${baseParameterFile} failed"; exit 1; }
 
 # Give this group its own stack name and unique identifier so the deployments,
 # log paths and teardown stay isolated from other groups in the same combination.
@@ -60,8 +54,8 @@ uniqueIdentifier=$(generateRandomString)
 baseStackName=$(extractParameters "StackName" "${groupParameterFile}")
 newStackName="${baseStackName}-${sanitizedGroup}-${uniqueIdentifier}"
 
-./scripts/write-parameter-file.sh "StackName" "${newStackName}" "${groupParameterFile}" 1>/dev/null
-./scripts/write-parameter-file.sh "UniqueIdentifier" "${uniqueIdentifier}" "${groupParameterFile}" 1>/dev/null
+${currentScript}/write-parameter-file.sh "StackName" "${newStackName}" "${groupParameterFile}" 1>/dev/null || { log_error "Writing StackName to ${groupParameterFile} failed"; exit 1; }
+${currentScript}/write-parameter-file.sh "UniqueIdentifier" "${uniqueIdentifier}" "${groupParameterFile}" 1>/dev/null || { log_error "Writing UniqueIdentifier to ${groupParameterFile} failed"; exit 1; }
 
 # Only the deployment directory name goes to stdout for the caller to capture.
 echo "${groupDeploymentName}"

--- a/scripts/write-parameter-file.sh
+++ b/scripts/write-parameter-file.sh
@@ -21,14 +21,17 @@
 required_variables=3
 
 if [ $# -ne ${required_variables} ]; then
-    log_error "${required_variables} variables required"
-    exit 0
-else
-    parameter_variable=${1}
-    parameter_value=${2}
-    parameter_file_path="${3}"
-    contents="$(jq --arg parameter_variable "$parameter_variable" \
-    --arg parameter_value "$parameter_value" \
-    '.Parameters[$parameter_variable] = $parameter_value' $parameter_file_path)" && \
-    echo "${contents}" > $parameter_file_path
+    echo "[ERROR]: ${required_variables} variables required (parameter name, value, file path)" >&2
+    exit 1
 fi
+
+parameter_variable=${1}
+parameter_value=${2}
+parameter_file_path="${3}"
+contents="$(jq --arg parameter_variable "$parameter_variable" \
+--arg parameter_value "$parameter_value" \
+'.Parameters[$parameter_variable] = $parameter_value' $parameter_file_path)" || {
+    echo "[ERROR]: Updating ${parameter_variable} in ${parameter_file_path} failed" >&2
+    exit 1
+}
+echo "${contents}" > $parameter_file_path


### PR DESCRIPTION
## Purpose

Follow-up to #298. A review of the phase-split per-group test flow surfaced 8 issues (verified against the source); this PR fixes them. The common thread: failures in auxiliary steps could either abort stack teardown or masquerade as success.

## Changes

**Teardown can no longer be skipped by a collect failure**
- `intg-test-deployment.sh`: the `collect` arm is now genuinely best-effort (`|| log_info`), matching its existing comment. Previously a missing remote surefire dir or a transient scp failure propagated through `shToBranchLog`'s `exit ${PIPESTATUS[0]}`, threw inside the Teardown stage's `finally`, skipped `teardown`, and failed a green build.
- `integration.groovy`: the Teardown stage additionally wraps collect in its own try/catch, so teardown runs no matter how the collect step dies.

**Phases fail honestly instead of surfacing errors later**
- `intg-test-executer.sh` `phaseSetup`: per-command error checks on wget / `aws s3 cp` / chmod / both scps. Previously the function's status was its last command (the infra.json scp), so a failed test-script download passed the `setup` gate and reappeared later as a remote "file not found".
- `prepare-group-deployment.sh`: the mkdir / cp / StackName / UniqueIdentifier steps now exit 1 on failure. Previously the script always exited 0 echoing the deployment name, so a failed StackName rewrite would leave every group deploying (and tearing down) the base combination's stack.
- `write-parameter-file.sh`: exits 1 to stderr on wrong arg count (was `exit 0` with a call to an unsourced `log_error`) and checks the jq result.

**Parallel-safety and cleanup**
- The test script is downloaded with `wget -O` into the per-deployment inputs directory and scp'd by absolute path. Previously all parallel group branches raced on the same bare filename in the shared workspace root, accumulating `.1, .2, …` copies.
- Clone failure no longer runs its own `post-actions.sh` (blocking 60s-poll delete) — the pipeline's Teardown stage owns stack deletion, so the self-teardown only wasted minutes and duplicated log noise.

**Deduplication and hardening**
- `generateRandomString` / `removeSpecialCharacters` hoisted into `common-functions.sh`; the three previously diverging copies (`deployment-builder.sh`, `parameter-file-handler.sh`, `prepare-group-deployment.sh`) are removed. `LC_ALL=C` added so `tr` cannot emit an empty suffix under UTF-8 locales.
- The sanitizer is now a whitelist (`[A-Za-z0-9-]`) instead of stripping a few known-bad characters, so nothing CloudFormation rejects can reach a StackName. Behavior-compatible for existing inputs (`3.2.0` → `320` either way).
- `parameter-file-handler.sh` now defines `currentScript` before using it to source `common-functions.sh` (previously undefined).

**Deliberately kept**
- The legacy `""|all` flow (`deploymentTest`, the executer's `all)` arm) is unreachable from the pipeline but retained for manual invocation — now commented as such, with its collect semantics aligned to the pipeline path so the two flows don't diverge on failure behavior.

## Verification

No Jenkins available locally, so verified by executing the scripts against a scratch `WORKSPACE`:
- `bash -n` clean on all seven touched scripts.
- `prepare-group-deployment.sh`: happy path emits exactly the group deployment name on stdout with StackName/UniqueIdentifier rewritten; missing base parameter file → exit 1 (the Groovy `returnStdout` caller throws instead of capturing garbage).
- `collect` phase with a failing executer → exit 0; `clone` with an unreachable repo → exit 1 with no post-actions run; `setup` with a failed wget → exit 1 (previously false success).
- Sanitizer: `grp:a/b.c_d,e f#g@h` → `grpabcdefgh`.
- The `integration.groovy` change is a plain try/catch in the existing idiom; not parse-checked locally (no groovy CLI) — worth a glance on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)