### PR TITLE
Check both surefire paths; drop unused ProductPackLocation write

### DIFF
--- a/integration.groovy
+++ b/integration.groovy
@@ -115,8 +115,6 @@ stages {
                     ./scripts/write-parameter-file.sh "TestType" "intg" "${WORKSPACE}/parameters/parameters.json"
                     echo "Writting product Surefire Report Directory"
                     ./scripts/write-parameter-file.sh "SurefireReportDir" ${surefire_report_dir} "${WORKSPACE}/parameters/parameters.json"
-                    echo "Writting product download location"
-                    ./scripts/write-parameter-file.sh "ProductPackLocation" ${product_pack_location} "${WORKSPACE}/parameters/parameters.json"
                     echo "Writing to parameter file completed!"
                     echo --- Preparing parameter files for deployments! ---
                     ./scripts/deployment-builder.sh ${product} ${product_version} '''+updateType+'''

--- a/scripts/intg-test-executer.sh
+++ b/scripts/intg-test-executer.sh
@@ -124,17 +124,17 @@ function phaseCollect(){
     log_info "Coping Surefire Reports to TestGrid Slave..."
 
     local repoRoot="/opt/testgrid/workspace/${PRODUCT_GIT_REPO_NAME}"
-    local configured="${repoRoot}/${TEST_REPORTS_DIR}/surefire-reports"
-
-    # Resolve the surefire-reports directory on the remote instance. Prefer the
-    # configured path (SurefireReportDir); if it is absent, discover it. The
+    # Configured path (SurefireReportDir) and the all-in-one-apim variant. The
     # module layout differs across product versions - e.g. APIM 4.5.0/4.6.0/4.7.0
     # nest the tests under an extra 'all-in-one-apim' directory - so a single
-    # hardcoded path cannot cover every version.
+    # hardcoded path cannot cover every version. Check both known locations and
+    # use whichever exists on the remote instance.
+    local configured="${repoRoot}/${TEST_REPORTS_DIR}/surefire-reports"
+    local allInOne="${repoRoot}/all-in-one-apim/${TEST_REPORTS_DIR}/surefire-reports"
     local remoteDir
     remoteDir=$(ssh ${SSH_OPTS} ${instanceUser}@${WSO2InstanceName} \
         "if [ -d '${configured}' ]; then echo '${configured}'; \
-         else find '${repoRoot}' -type d -name surefire-reports 2>/dev/null | head -1; fi")
+         elif [ -d '${allInOne}' ]; then echo '${allInOne}'; fi")
 
     if [[ -z "${remoteDir}" ]]; then
         log_info "No surefire-reports directory found on remote for ${productTestGroup}; skipping report collection"


### PR DESCRIPTION
This pull request simplifies the handling of Surefire report directory paths during integration test execution and parameter file preparation. The main focus is on improving the robustness of Surefire report collection to support different product version layouts.

**Integration test execution improvements:**

* Updated the logic in `scripts/intg-test-executer.sh` to check both the standard and `all-in-one-apim` Surefire report directory locations, ensuring compatibility with different product versions and layouts. Now, the script will use whichever directory exists on the remote instance, improving reliability of report collection.

**Parameter file preparation cleanup:**

* Removed the writing of the `ProductPackLocation` parameter in the `integration.groovy` pipeline, as it is no longer needed for the workflow.