### PR TITLE
[APIM440] Bind registry pull credential and fix the db_version default

### DIFF
--- a/kubernetes/product-deployment/440_main.jenkins
+++ b/kubernetes/product-deployment/440_main.jenkins
@@ -98,7 +98,7 @@ pipeline {
                             ),
                             string(
                                 name: 'db_version',
-                                defaultValue: '5.7.44',
+                                defaultValue: '5.7.44-rds.20250508',
                                 description: 'Database engine version',
                                 trim: true
                             ),

--- a/kubernetes/product-deployment/440_main.jenkins
+++ b/kubernetes/product-deployment/440_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        REGISTRY_CREDS = credentials('wso2-apim_jenkins_image_pull_user')
         SHORT_PRODUCT_VERSION = '440'
     }
     stages {


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10. The APIM440 Kubernetes deployment pipeline pulls prebuilt subscription images from it, so every build since has failed — the pods run on Fargate, where an unpullable image leaves them in `Pending` rather than `ImagePullBackOff`, so the build burns the full `kubectl wait --timeout=1800s` and fails after ~165 minutes with no error message.

The `am-pattern-4` chart has already been repointed to `registry.wso2.com`. The remaining blocker is authentication: the pipeline currently passes the WUM credentials to the chart, and those are only valid against WSO2 Updates — not the container registry.

## Goals
Give the APIM440 pipeline a registry credential that is independent of the WUM one, so the image pull and the in-container update tool can authenticate against their own services.

## Approach
Bind the new `wso2-apim_jenkins_image_pull_user` credential (Username with password) in the `environment` block of `440_main.jenkins`.

Because `environment` entries are exported to every `sh` step, `deploy.sh` receives `REGISTRY_CREDS_USR` and `REGISTRY_CREDS_PSW` without any change to the invocation or its arguments. The companion change in `apim-test-integration` consumes them to create a dedicated `docker-registry` secret.

`WUM_USER` / `WUM_PWD` are deliberately unchanged — they continue to populate `wso2.subscription.*`, which drives `wso2update_linux` in the container entrypoint.

Scoped to APIM440 only. The same one-liner applies to `430_main.jenkins` and the remaining pipelines once this is verified green.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal pipeline configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams; this is a CI credential binding.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — declarative pipeline configuration.
- Integration tests
  > Verified by running the APIM440 pipeline itself. Blocked on the credential being created in Jenkins; the change is a no-op until then.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the change references a Jenkins credential ID only; no secret values are committed.

## Samples
N/A

## Related PRs
- wso2/apim-test-integration — consumes the bound credential to create the image pull secret (companion change, required for this to have any effect).

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential (Username with password) to exist on the Jenkins controller, scoped to the `Kubernetes-deployments/APIM` folder or global. The build will fail to start if the ID is missing.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM440`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-4-0`.

## Learning
The chart already exposes `wso2.deployment.am.imagePullSecrets` in all five AM deployment templates, taking precedence over the subscription-derived secret. That made it possible to separate the two credentials without any change to the Helm charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
