### PR TITLE
[APIM430] Bind registry pull credential and fix the db_version default

### DIFF
--- a/kubernetes/product-deployment/430_main.jenkins
+++ b/kubernetes/product-deployment/430_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        REGISTRY_CREDS = credentials('wso2-apim_jenkins_image_pull_user')
         SHORT_PRODUCT_VERSION = '430'
     }
     stages {
@@ -97,7 +98,7 @@ pipeline {
                             ),
                             string(
                                 name: 'db_version',
-                                defaultValue: '5.7.44',
+                                defaultValue: '5.7.44-rds.20250508',
                                 description: 'Database engine version',
                                 trim: true
                             ),


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10. The APIM430 Kubernetes deployment pipeline pulls prebuilt subscription images from it, so every build since has failed — the pods run on Fargate, where an unpullable image leaves them in `Pending` rather than `ImagePullBackOff`, so the build burns the full `kubectl wait --timeout=1800s` and fails after ~165 minutes with no error message.

The `am-pattern-4` chart has already been repointed to `registry.wso2.com`. The remaining blocker is authentication: the pipeline currently passes the WUM credentials to the chart, and those are only valid against WSO2 Updates — not the container registry.

This is the APIM430 counterpart of #307, which is verified green in APIM440 build #184.

## Goals
Give the APIM430 pipeline a registry credential independent of the WUM one, and make the job triggerable on its defaults again.

## Approach
Two changes to `430_main.jenkins`:

1. Bind the `wso2-apim_jenkins_image_pull_user` credential (Username with password) in the `environment` block. Since `environment` entries are exported to every `sh` step, `deploy.sh` receives `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW` with no change to the invocation. The companion change in `apim-test-integration` consumes them.

2. Default `db_version` to `5.7.44-rds.20250508`. The declared default was a bare `5.7.44`, which RDS no longer accepts for new instances — the CloudFormation stack rolls back with *"Cannot find version 5.7.44 for mysql"*. Every green run has needed the suffix typed in by hand.

`WUM_USER` / `WUM_PWD` are deliberately unchanged — they continue to populate `wso2.subscription.*`, which drives `wso2update_linux` in the container entrypoint.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal pipeline configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams; this is a CI credential binding.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — declarative pipeline configuration.
- Integration tests
  > Verified by running the APIM430 pipeline itself against this branch — build #233, SUCCESS, 195/195 tests passing. See the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the change references a Jenkins credential ID only; no secret values are committed.

## Samples
N/A

## Related PRs
- wso2/apim-test-integration — APIM430 pull secret creation (companion change, required for this to have any effect).
- wso2/testgrid-jenkins-library#307 — the equivalent APIM440 change.

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential (Username with password) on the Jenkins controller, scoped to the `Kubernetes-deployments/APIM` folder or global. Already created.

Note that `properties([parameters([...])])` rewrites the job's stored defaults *during* a build, so the new `db_version` default takes effect from the second run after merge; the first still needs the override typed in.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM430`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-3-0`.

## Learning
The chart already exposes `wso2.deployment.am.imagePullSecrets` in all five AM deployment templates, taking precedence over the subscription-derived secret. That made it possible to separate the two credentials without any change to the Helm charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
