### PR TITLE
[APIM420] Bind registry pull credential and fix the db_version default

### DIFF
--- a/kubernetes/product-deployment/420_main.jenkins
+++ b/kubernetes/product-deployment/420_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        REGISTRY_CREDS = credentials('wso2-apim_jenkins_image_pull_user')
         SHORT_PRODUCT_VERSION = '420'
     }
     stages {
@@ -97,7 +98,7 @@ pipeline {
                             ),
                             string(
                                 name: 'db_version',
-                                defaultValue: '5.7.44',
+                                defaultValue: '5.7.44-rds.20250508',
                                 description: 'Database engine version',
                                 trim: true
                             ),


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10, so the APIM420 Kubernetes deployment pipeline can no longer pull product images. The pods run on Fargate, where an unpullable image leaves them in `Pending` rather than `ImagePullBackOff`, so the build burns the full `kubectl wait --timeout=1800s` and fails after ~165 minutes with no error message.

Third in the series after #307 (APIM440) and #308 (APIM430), both verified green.

## Goals
Give the APIM420 pipeline a registry credential independent of the WUM one, and make the job triggerable on its defaults again.

## Approach
Two changes to `420_main.jenkins`:

1. Bind the `wso2-apim_jenkins_image_pull_user` credential (Username with password) in the `environment` block. Since `environment` entries are exported to every `sh` step, `deploy.sh` receives `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW` with no change to the invocation.

2. Default `db_version` to `5.7.44-rds.20250508`. The bare `5.7.44` is no longer offered by RDS and rolls the CloudFormation stack back — this pipeline already lost build #293 to it on 19 July, and APIM440 lost #181 to the same thing on 10 August.

Note APIM420 differs from 430/440: its chart comes from upstream `wso2/kubernetes-apim@4.2.x`, which still points at `docker.wso2.com` with a single-segment image name that Harbor rejects. Rather than fork a chart repository already marked deprecated, the companion `deploy.sh` change overrides the registry and image path on the `helm install`. Nothing outside these two repositories has to move.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal pipeline configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams; this is a CI credential binding.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — declarative pipeline configuration.
- Integration tests
  > Verified by running the APIM420 pipeline against this branch — build #301, SUCCESS, 195/195 tests passing. See the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the change references a Jenkins credential ID only; no secret values are committed.

## Samples
N/A

## Related PRs
- wso2/apim-test-integration — APIM420 registry overrides and pull secret (companion change, required for this to have any effect).
- wso2/testgrid-jenkins-library#307 (APIM440), #308 (APIM430) — the equivalent changes.

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential (Username with password) on the Jenkins controller, scoped to the `Kubernetes-deployments/APIM` folder or global. Already created.

Note that `properties([parameters([...])])` rewrites the job's stored defaults *during* a build, so the new `db_version` default takes effect from the second run after merge; the first still needs the override typed in.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM420`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-2-0`.

## Learning
The 4.2.x chart does not invoke `wso2update_linux` at all — `wso2.subscription.*` only ever fed the image pull secret there, and the update level comes solely from the pinned image tag. Worth noting separately: that means APIM420 has been validating the GA pack rather than the latest update level. That is pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
