### PR TITLE
[APIM410] Bind registry pull credential and fix the db_version default

### DIFF
--- a/kubernetes/product-deployment/410_main.jenkins
+++ b/kubernetes/product-deployment/410_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        REGISTRY_CREDS = credentials('wso2-apim_jenkins_image_pull_user')
         SHORT_PRODUCT_VERSION = '410'
     }
     stages {
@@ -97,7 +98,7 @@ pipeline {
                             ),
                             string(
                                 name: 'db_version',
-                                defaultValue: '8.0.36',
+                                defaultValue: '8.0.43',
                                 description: 'Database engine version',
                                 trim: true
                             ),


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10, so the APIM410 Kubernetes deployment pipeline can no longer pull product images. The pods run on Fargate, where an unpullable image leaves them `Pending` rather than `ImagePullBackOff`, so the build burns the full `kubectl wait --timeout=1800s`.

Fourth in the series after #307 (APIM440), #308 (APIM430) and #309 (APIM420).

## Goals
Give APIM410 a registry credential independent of the WUM one, and make the job triggerable on its defaults again.

## Approach
Two changes to `410_main.jenkins`:

1. Bind `wso2-apim_jenkins_image_pull_user` (Username with password) in the `environment` block. `environment` entries are exported to every `sh` step, so `deploy.sh` receives `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW` with no change to the invocation.

2. Default `db_version` to `8.0.43`. RDS no longer offers `8.0.36` — build **#304** failed on `Cannot find version 8.0.36 for mysql` on 2026-08-07, and **#305** passed an hour later only because `8.0.43` was typed in by hand. Note this differs from the 4.2.0/4.3.0/4.4.0 pipelines, which are on MySQL 5.7.

`WUM_USER` / `WUM_PWD` are unchanged and continue to populate `wso2.subscription.*`.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal pipeline configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — declarative pipeline configuration.
- Integration tests
  > Verified by running APIM410 against this branch — build **#306**. The deployment succeeded: all five AM pods pulled from `registry.wso2.com` and reached `condition met`, and 181 tests passed. The build is nonetheless red on 12 failures in one suite, which are unrelated to this change — see the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — references a Jenkins credential ID only.

## Samples
N/A

## Related PRs
- wso2/apim-test-integration — APIM410 registry overrides and pull secret (companion; this PR is a no-op without it).
- wso2/testgrid-jenkins-library#307 (APIM440), #308 (APIM430), #309 (APIM420).

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential on the Jenkins controller, scoped to `Kubernetes-deployments/APIM` or global. Already created.

`properties([parameters([...])])` rewrites the job's stored defaults *during* a build, so the new `db_version` default takes effect from the second run after merge.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM410`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-1-0`.

## Learning
`db_version` defaults rot silently. Three of the four pipelines in this series had a default RDS no longer accepts, each failing ~70 seconds in with a message that looks nothing like "your default is stale". Worth a periodic check against `aws rds describe-db-engine-versions` rather than waiting for the next red build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
