### PR TITLE
[APIM400] Bind registry pull credential and fix the db_version default

### DIFF
--- a/kubernetes/product-deployment/400_main.jenkins
+++ b/kubernetes/product-deployment/400_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        REGISTRY_CREDS = credentials('wso2-apim_jenkins_image_pull_user')
         SHORT_PRODUCT_VERSION = '400'
     }
     stages {
@@ -97,7 +98,7 @@ pipeline {
                             ),
                             string(
                                 name: 'db_version',
-                                defaultValue: '5.7.44',
+                                defaultValue: '5.7.44-rds.20250508',
                                 description: 'Database engine version',
                                 trim: true
                             ),


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10, so the APIM400 Kubernetes deployment pipeline can no longer pull product images. The pods run on Fargate, where an unpullable image leaves them `Pending` rather than `ImagePullBackOff`, so the build burns the full `kubectl wait --timeout=1800s` and fails after ~165 minutes with no error message.

Last in the series after #307 (APIM440), #308 (APIM430), #309 (APIM420) and #310 (APIM410).

## Goals
Give APIM400 a registry credential independent of the WUM one, and make the job triggerable on its defaults again.

## Approach
Two changes to `400_main.jenkins`:

1. Bind `wso2-apim_jenkins_image_pull_user` (Username with password) in the `environment` block. `environment` entries are exported to every `sh` step, so `deploy.sh` receives `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW` with no change to the invocation.

2. Default `db_version` to `5.7.44-rds.20250508`. RDS no longer offers the bare `5.7.44`; build #287 passed only because the suffixed version was supplied by hand.

`WUM_USER` / `WUM_PWD` are unchanged and continue to populate `wso2.subscription.*`.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal pipeline configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — declarative pipeline configuration.
- Integration tests
  > Verified by running APIM400 against this branch — build **#288**, SUCCESS, 170/170 passing, 28.7 min. See the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — references a Jenkins credential ID only.

## Samples
N/A

## Related PRs
- wso2/apim-test-integration — APIM400 registry overrides and pull secret (companion; this PR is a no-op without it).
- wso2/testgrid-jenkins-library#307 (APIM440), #308 (APIM430), #309 (APIM420), #310 (APIM410).

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential on the Jenkins controller, scoped to `Kubernetes-deployments/APIM` or global. Already created.

`properties([parameters([...])])` rewrites the job's stored defaults *during* a build, so the new `db_version` default takes effect from the second run after merge.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM400`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-4-0-0`.

## Learning
With this merged, all six pipelines that consume prebuilt subscription images are migrated. The two remaining APIM pipelines (320, 321) use `am-pattern-2` charts from a different repository and will need separate treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
