### PR TITLE
[APIM321] Bind registry pull credential and fix the db_version default

### DIFF
--- a/kubernetes/product-deployment/321_main.jenkins
+++ b/kubernetes/product-deployment/321_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        REGISTRY_CREDS = credentials('wso2-apim_jenkins_image_pull_user')
         SHORT_PRODUCT_VERSION = '321'
     }
     stages {
@@ -97,7 +98,7 @@ pipeline {
                             ),
                             string(
                                 name: 'db_version',
-                                defaultValue: '8.0.36',
+                                defaultValue: '8.0.43',
                                 description: 'Database engine version',
                                 trim: true
                             ),


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10, so the APIM321 Kubernetes deployment pipeline can no longer pull product images.

Part of the series with #307 (APIM440), #308 (APIM430), #309 (APIM420), #310 (APIM410) and #311 (APIM400).

## Goals
Give APIM321 a registry credential independent of the WUM one, and make the job triggerable on its defaults again.

## Approach
Two changes to `321_main.jenkins`:

1. Bind `wso2-apim_jenkins_image_pull_user` (Username with password) in the `environment` block, so `deploy.sh` receives `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW`.
2. Default `db_version` to `8.0.43`. RDS no longer offers `8.0.36`; build #197 passed only because `8.0.43` was supplied by hand.

`WUM_USER` / `WUM_PWD` are unchanged.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal pipeline configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — declarative pipeline configuration.
- Integration tests
  > Run against this branch — build **#201**. The deployment succeeded: all five pods, across three different images, pulled from `registry.wso2.com` and reached `condition met`. The build is red on 4 analytics assertions, but those are pre-existing and intermittent — the same four failed on 2026-08-07 with the old `docker.wso2.com` images. See the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — references a Jenkins credential ID only.

## Samples
N/A

## Related PRs
- wso2/apim-test-integration — APIM321 registry overrides and pull secret (companion; this PR is a no-op without it).
- wso2/testgrid-jenkins-library#307, #308, #309, #310, #311.

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential on the Jenkins controller, scoped to `Kubernetes-deployments/APIM` or global. Already created.

`properties([parameters([...])])` rewrites stored defaults *during* a build, so the new `db_version` default applies from the second run after merge.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM321`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-3-2-1`.

## Learning
`8.0.36` was the stale default on APIM321, APIM320 and APIM410; `5.7.44` on the other four. Six of seven pipelines could not be triggered on their own defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

