### PR TITLE
[APIM320] Bind registry pull credential and fix the db_version default

### DIFF
--- a/kubernetes/product-deployment/320_main.jenkins
+++ b/kubernetes/product-deployment/320_main.jenkins
@@ -27,6 +27,7 @@ pipeline {
         DB_PASSWORD = '613296496' 
         WUM_USER = credentials('WUM_USERNAME')
         WUM_PWD = credentials('WUM_PASSWORD')
+        REGISTRY_CREDS = credentials('wso2-apim_jenkins_image_pull_user')
         SHORT_PRODUCT_VERSION = '320'
     }
     stages {
@@ -97,7 +98,7 @@ pipeline {
                             ),
                             string(
                                 name: 'db_version',
-                                defaultValue: '8.0.36',
+                                defaultValue: '8.0.43',
                                 description: 'Database engine version',
                                 trim: true
                             ),


### PR DESCRIPTION
## Purpose
`docker.wso2.com` was decommissioned on 2026-08-10, so the APIM320 Kubernetes deployment pipeline can no longer pull product images.

Completes the series with #307 (APIM440), #308 (APIM430), #309 (APIM420), #310 (APIM410), #311 (APIM400) and #312 (APIM321).

## Goals
Give APIM320 a registry credential independent of the WUM one, and make the job triggerable on its defaults again.

## Approach
Two changes to `320_main.jenkins`:

1. Bind `wso2-apim_jenkins_image_pull_user` (Username with password) in the `environment` block, so `deploy.sh` receives `REGISTRY_CREDS_USR` / `REGISTRY_CREDS_PSW`.
2. Default `db_version` to `8.0.43`. RDS no longer offers `8.0.36`; build #292 passed only because `8.0.43` was supplied by hand.

`WUM_USER` / `WUM_PWD` are unchanged.

## User stories
N/A — CI infrastructure change.

## Release note
N/A — not a product change.

## Documentation
N/A — internal pipeline configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests
  > N/A — declarative pipeline configuration.
- Integration tests
  > Verified by running APIM320 against this branch — build **#293**, SUCCESS, 165/165 passing, 31.2 min. See the comment below.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — references a Jenkins credential ID only.

## Samples
N/A

## Related PRs
- wso2/apim-test-integration — APIM320 registry overrides and pull secret (companion; this PR is a no-op without it).
- wso2/testgrid-jenkins-library#307, #308, #309, #310, #311, #312.

## Migrations (if applicable)
Requires the `wso2-apim_jenkins_image_pull_user` credential on the Jenkins controller, scoped to `Kubernetes-deployments/APIM` or global. Already created.

`properties([parameters([...])])` rewrites stored defaults *during* a build, so the new `db_version` default applies from the second run after merge.

## Test environment
`testgrid.wso2.com`, `Kubernetes-deployments/APIM/APIM320`, EKS cluster `testgrid-eks-cluster` (us-east-1), namespace `apim-3-2-0`.

## Learning
With this merged, all seven APIM pipelines are migrated off `docker.wso2.com`. Six of the seven also could not be triggered on their own `db_version` defaults — `8.0.36` on 320/321/410, `5.7.44` on the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
